### PR TITLE
LAT-125 schema updates

### DIFF
--- a/src/encoded/schemas/cell_annotation.json
+++ b/src/encoded/schemas/cell_annotation.json
@@ -5,9 +5,10 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "required": ["author_cell_type"],
-    "identifyingProperties": ["uuid"],
+    "identifyingProperties": ["uuid", "aliases"],
     "additionalProperties": false,
     "mixinProperties": [
+        {"$ref": "mixins.json#/aliases"},
         {"$ref": "mixins.json#/notes"},
         {"$ref": "mixins.json#/schema_version"},
         {"$ref": "mixins.json#/standard_status"},

--- a/src/encoded/schemas/cell_culture.json
+++ b/src/encoded/schemas/cell_culture.json
@@ -91,6 +91,15 @@
         }
     },
     "facets": {
+        "donors.organism.scientific_name": {
+            "title": "Organism"
+        },
+        "donors.life_stage": {
+            "title": "Donor life stage"
+        },
+        "donors.sex": {
+            "title": "Donor sex"
+        },
         "biosample_ontology.system_slims": {
             "title": "System"
         },
@@ -106,6 +115,9 @@
             "title": "Biosample term name",
             "type": "typeahead"
         },
+        "diseases.term_name": {
+            "title": "Disease"
+        },
         "status": {
             "title": "Status"
         }
@@ -120,6 +132,15 @@
         "description": {
             "title": "Description"
         },
+        "donors.organism.scientific_name": {
+            "title": "Organism"
+        },
+        "donors.life_stage": {
+            "title": "Donor life stage"
+        },
+        "donors.sex": {
+            "title": "Donor sex"
+        },
         "biosample_ontology.system_slims": {
             "title": "System"
         },
@@ -128,6 +149,9 @@
         },
         "biosample_ontology.cell_slims": {
             "title": "Cell"
+        },
+        "diseases.term_name": {
+            "title": "Disease"
         },
         "derived_from": {
             "title": "Derived from"

--- a/src/encoded/schemas/cell_culture.json
+++ b/src/encoded/schemas/cell_culture.json
@@ -117,9 +117,6 @@
         "biosample_ontology.term_name": {
             "title": "Biosample term name"
         },
-        "summary": {
-            "title": "Summary"
-        },
         "description": {
             "title": "Description"
         },

--- a/src/encoded/schemas/changelogs/organism.md
+++ b/src/encoded/schemas/changelogs/organism.md
@@ -1,4 +1,7 @@
 ## Changelog for organism.json
 
+### Schema version 3
+* Update *taxon_id* values prefix changes to "NCBITaxon:" from" "NBCI:"
+
 ### Schema version 2
 * Update *ncbi_taxon_id* property to *taxon_id* and included the "NBCI:" prefix in the value

--- a/src/encoded/schemas/changelogs/publication.md
+++ b/src/encoded/schemas/changelogs/publication.md
@@ -1,0 +1,4 @@
+## Changelog for publication.json
+
+### Schema version 2
+* *doi* and *pmid* replace *identifiers* as the location of reference identifiers

--- a/src/encoded/schemas/dataset.json
+++ b/src/encoded/schemas/dataset.json
@@ -46,6 +46,14 @@
             "type": "string",
             "linkTo": "Award"
         },
+        "dataset_title": {
+            "title": "Dataset title",
+            "description": "The title of this dataset, to be displayed in external resources, like the HCA DCP.",
+            "type": "string"
+        },
+        "description": {
+            "description": "A summary of this dataset, to be displayed in external resources, like the HCA DCP."
+        },
         "corresponding_contributor": {
             "title": "Corresponding contributor",
             "description": "The user who is the primary external contact for the dataset.",
@@ -57,6 +65,14 @@
             "description": "The Lattice contact for questions about the details of the experiment and/or analysis.",
             "type": "string",
             "linkTo": "User"
+        },
+        "funding_organizations": {
+            "title": "Funding organizations",
+            "description": "The list of organizations that contributed funding to the generation of these data.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         },
         "date_released": {
             "title": "Date released",

--- a/src/encoded/schemas/dataset.json
+++ b/src/encoded/schemas/dataset.json
@@ -54,11 +54,23 @@
         "description": {
             "description": "A summary of this dataset, to be displayed in external resources, like the HCA DCP."
         },
-        "corresponding_contributor": {
-            "title": "Corresponding contributor",
+        "corresponding_contributors": {
+            "title": "Corresponding contributors",
             "description": "The user who is the primary external contact for the dataset.",
-            "type": "string",
-            "linkTo": "User"
+            "type": "array",
+            "items": {
+                "type": "string",
+                "linkTo": "User"
+            }
+        },
+        "contributors": {
+            "title": "Contributors",
+            "description": "The user who is the primary external contact for the dataset.",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "linkTo": "User"
+            }
         },
         "internal_contact": {
             "title": "Internal contact",

--- a/src/encoded/schemas/dataset.json
+++ b/src/encoded/schemas/dataset.json
@@ -143,6 +143,9 @@
         "accession": {
             "title": "Accession"
         },
+        "dataset_title": {
+            "title": "Dataset title"
+        },
         "award.project": {
             "title": "Project"
         },

--- a/src/encoded/schemas/human_postnatal_donor.json
+++ b/src/encoded/schemas/human_postnatal_donor.json
@@ -210,6 +210,9 @@
         "ethnicity.term_name": {
             "title": "Ethnicity"
         },
+        "diseases.term_name": {
+            "title": "Disease"
+        },
         "status": {
             "title": "Status"
         }
@@ -232,6 +235,9 @@
         },
         "ethnicity.term_name": {
             "title": "Ethnicity"
+        },
+        "diseases.term_name": {
+            "title": "Disease"
         },
         "body_mass_index": {
             "title": "BMI"

--- a/src/encoded/schemas/human_prenatal_donor.json
+++ b/src/encoded/schemas/human_prenatal_donor.json
@@ -101,6 +101,9 @@
         "ethnicity.term_name": {
             "title": "Ethnicity"
         },
+        "diseases.term_name": {
+            "title": "Disease"
+        },
         "status": {
             "title": "Status"
         }
@@ -126,6 +129,9 @@
         },
         "ethnicity.term_name": {
             "title": "Ethnicity"
+        },
+        "diseases.term_name": {
+            "title": "Disease"
         },
         "status": {
             "title": "Status"

--- a/src/encoded/schemas/library_protocol.json
+++ b/src/encoded/schemas/library_protocol.json
@@ -177,7 +177,7 @@
             ]
         },
         "polyA_selection": {
-            "title": "PolyA selection",
+            "title": "polyA selection",
             "description": "A flag to indicate whether or not there was step in the experimental protocol to select for polyA in the mRNA.",
             "type": "boolean"
         },

--- a/src/encoded/schemas/matrix_file.json
+++ b/src/encoded/schemas/matrix_file.json
@@ -176,6 +176,12 @@
                 "X_tsne"
             ]
         },
+        "experimental_variable_disease": {
+            "title": "Experimental variable disease",
+            "description": "The primary disease variable used in the analysis of data within this matrix, distinguishing the disease group from the control, or normal, group.",
+            "type": "string",
+            "linkTo": "OntologyTerm"
+        },
         "layers": {
             "title": "Layers",
             "description": "",
@@ -188,7 +194,7 @@
                 "properties": {
                     "label": {
                         "title": "Label",
-                        "description": "",
+                        "description": "For AnnData h5ad final matrix files, the name used to describe the layer. Required for a layer that is not raw counts and is not the visualization layer.",
                         "type": "string"
                     },
                     "assay": {
@@ -310,10 +316,11 @@
                                         "percent ribosomal protein large subunits",
                                         "percent ribosomal protein small subunits",
                                         "fragments in peaks/nuclei",
-                                        "percent in peaks/nuclei",
+                                        "percent fragments in peaks/nuclei",
                                         "TSS enrichment score/nuclei",
                                         "blacklist ratio/nuclei",
                                         "doublet score/nuclei",
+                                        "nucleosome signal/nuclei",
                                         "per batch distribution percent genes/cell",
                                         "per batch distribution percent genes/nuclei",
                                         "per batch distribution percent umi/cell",

--- a/src/encoded/schemas/matrix_file.json
+++ b/src/encoded/schemas/matrix_file.json
@@ -398,6 +398,9 @@
         }
     },
     "facets": {
+        "assays": {
+            "title": "Assays"
+        },
         "output_types": {
             "title": "Output type"
         },

--- a/src/encoded/schemas/mouse_postnatal_donor.json
+++ b/src/encoded/schemas/mouse_postnatal_donor.json
@@ -91,6 +91,9 @@
         "strain_term_name": {
             "title": "Strain"
         },
+        "diseases.term_name": {
+            "title": "Disease"
+        },
         "status": {
             "title": "Status"
         }
@@ -113,6 +116,9 @@
         },
         "strain_term_name": {
             "title": "Strain"
+        },
+        "diseases.term_name": {
+            "title": "Disease"
         },
         "status": {
             "title": "Status"

--- a/src/encoded/schemas/mouse_prenatal_donor.json
+++ b/src/encoded/schemas/mouse_prenatal_donor.json
@@ -120,6 +120,9 @@
         "strain_term_name": {
             "title": "Strain"
         },
+        "diseases.term_name": {
+            "title": "Disease"
+        },
         "status": {
             "title": "Status"
         }
@@ -145,6 +148,9 @@
         },
         "strain_term_name": {
             "title": "Strain"
+        },
+        "diseases.term_name": {
+            "title": "Disease"
         },
         "status": {
             "title": "Status"

--- a/src/encoded/schemas/organism.json
+++ b/src/encoded/schemas/organism.json
@@ -14,7 +14,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "2"
+            "default": "3"
         },
         "name": {
             "title": "Name",
@@ -31,9 +31,9 @@
         },
         "taxon_id": {
             "title": "Taxon ID",
-            "description": "The NCBI taxon ID for the organism (e.g. NCBI:10090).",
+            "description": "The NCBI taxon ID for the organism (e.g. NCBITaxon:10090).",
             "type": "string",
-            "format": "^(NCBI:[0-9])+$"
+            "format": "^(NCBITaxon:[0-9])+$"
         }
     },
     "facets": {

--- a/src/encoded/schemas/organoid.json
+++ b/src/encoded/schemas/organoid.json
@@ -94,9 +94,6 @@
         "biosample_ontology.term_name": {
             "title": "Biosample term name"
         },
-        "summary": {
-            "title": "Summary"
-        },
         "description": {
             "title": "Description"
         },

--- a/src/encoded/schemas/organoid.json
+++ b/src/encoded/schemas/organoid.json
@@ -72,6 +72,15 @@
         }
     },
     "facets": {
+        "donors.organism.scientific_name": {
+            "title": "Organism"
+        },
+        "donors.life_stage": {
+            "title": "Donor life stage"
+        },
+        "donors.sex": {
+            "title": "Donor sex"
+        },
         "biosample_ontology.system_slims": {
             "title": "System"
         },
@@ -82,6 +91,9 @@
         "biosample_ontology.term_name": {
             "title": "Biosample term name",
             "type": "typeahead"
+        },
+        "diseases.term_name": {
+            "title": "Disease"
         },
         "status": {
             "title": "Status"
@@ -97,11 +109,23 @@
         "description": {
             "title": "Description"
         },
+        "donors.organism.scientific_name": {
+            "title": "Organism"
+        },
+        "donors.life_stage": {
+            "title": "Donor life stage"
+        },
+        "donors.sex": {
+            "title": "Donor sex"
+        },
         "biosample_ontology.system_slims": {
             "title": "System"
         },
         "biosample_ontology.organ_slims": {
             "title": "Organ"
+        },
+        "diseases.term_name": {
+            "title": "Disease"
         },
         "derived_from": {
             "title": "Derived from"

--- a/src/encoded/schemas/publication.json
+++ b/src/encoded/schemas/publication.json
@@ -15,7 +15,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "1"
+            "default": "2"
         },
         "status": {
             "default": "released"
@@ -62,18 +62,19 @@
             "description": "The journal of the publication.",
             "type": "string"
         },
-        "identifiers": {
-            "title": "Identifiers",
-            "description": "The PubMed and DOI identifiers that corresponds to the published work.",
-            "type": "array",
-            "uniqueItems": true,
-            "items": {
-                "title": "Identifier",
-                "description": "A PubMed or DOI identifier that corresponds to the published work.",
-                "type": "string",
-                "uniqueKey":  "publication:identifier",
-                "pattern": "^(PMID:[0-9]+|doi:10\\.[0-9]{4}[\\d\\s\\S\\:\\.\\/]+)$"
-            }
+        "doi": {
+            "title": "DOI",
+            "description": "A DOI identifier that corresponds to the published work.",
+            "type": "string",
+            "uniqueKey":  "publication:doi",
+            "pattern": "^(10\\.[0-9]{4}[\\d\\s\\S\\:\\.\\/]+)$"
+        },
+        "pmid": {
+            "title": "PubMed ID",
+            "description": "A PubMed identifier that corresponds to the published work.",
+            "type": "string",
+            "uniqueKey":  "publication:pmid",
+            "pattern": "^([0-9]+)$"
         },
         "award": {
             "title": "Award",
@@ -112,6 +113,12 @@
         "publication_year": {
             "title": "Publication year"
         },
+        "pmid": {
+            "title": "PubMed ID"
+        },
+        "doi": {
+            "title": "DOI"
+        },
         "datasets": {
             "title": "Datasets"
         },
@@ -123,11 +130,7 @@
         },
         "status": {
             "title": "Status"
-        },
-        "identifiers": {
-            "title": "Identifiers"
         }
     },
     "changelog": "/profiles/changelogs/publication.md"
-
 }

--- a/src/encoded/schemas/raw_sequence_file.json
+++ b/src/encoded/schemas/raw_sequence_file.json
@@ -70,7 +70,8 @@
                 "type":  "string",
                 "enum": [
                      "filtering",
-                     "concatenation"
+                     "concatenation",
+                     "demultiplexing"
                  ]
             }
         },

--- a/src/encoded/schemas/suspension.json
+++ b/src/encoded/schemas/suspension.json
@@ -286,6 +286,15 @@
         }
     },
     "facets": {
+        "donors.organism.scientific_name": {
+            "title": "Organism"
+        },
+        "donors.life_stage": {
+            "title": "Donor life stage"
+        },
+        "donors.sex": {
+            "title": "Donor sex"
+        },
         "suspension_type": {
             "title": "Suspension type"
         },
@@ -314,6 +323,15 @@
         },
         "description": {
             "title": "Description"
+        },
+        "donors.organism.scientific_name": {
+            "title": "Organism"
+        },
+        "donors.life_stage": {
+            "title": "Donor life stage"
+        },
+        "donors.sex": {
+            "title": "Donor sex"
         },
         "derived_from": {
             "title": "Derived from"

--- a/src/encoded/schemas/tissue.json
+++ b/src/encoded/schemas/tissue.json
@@ -188,6 +188,15 @@
         }
     },
     "facets": {
+        "donors.organism.scientific_name": {
+            "title": "Organism"
+        },
+        "donors.life_stage": {
+            "title": "Donor life stage"
+        },
+        "donors.sex": {
+            "title": "Donor sex"
+        },
         "biosample_ontology.system_slims": {
             "title": "System"
         },
@@ -198,6 +207,9 @@
         "biosample_ontology.term_name": {
             "title": "Biosample term name",
             "type": "typeahead"
+        },
+        "diseases.term_name": {
+            "title": "Disease"
         },
         "status": {
             "title": "Status"
@@ -213,11 +225,26 @@
         "description": {
             "title": "Description"
         },
+        "donors.organism.scientific_name": {
+            "title": "Organism"
+        },
+        "donors.life_stage": {
+            "title": "Donor life stage"
+        },
+        "donors.sex": {
+            "title": "Donor sex"
+        },
+        "treatment_summary": {
+            "title": "Treatment summary"
+        },
         "biosample_ontology.system_slims": {
             "title": "System"
         },
         "biosample_ontology.organ_slims": {
             "title": "Organ"
+        },
+        "diseases.term_name": {
+            "title": "Disease"
         },
         "derived_from": {
             "title": "Derived from"

--- a/src/encoded/schemas/tissue.json
+++ b/src/encoded/schemas/tissue.json
@@ -210,9 +210,6 @@
         "biosample_ontology.term_name": {
             "title": "Biosample term name"
         },
-        "summary": {
-            "title": "Summary"
-        },
         "description": {
             "title": "Description"
         },

--- a/src/encoded/schemas/treatment.json
+++ b/src/encoded/schemas/treatment.json
@@ -180,6 +180,9 @@
         "treatment_type": {
             "title": "Treatment type"
         },
+        "summary": {
+            "title": "Treatment summary"
+        },
         "purpose": {
             "title": "Purpose"
         },

--- a/src/encoded/schemas/user.json
+++ b/src/encoded/schemas/user.json
@@ -42,6 +42,12 @@
             "type": "string",
             "linkTo": "Lab"
         },
+        "institute_name": {
+            "title": "Institute",
+            "description": "The name for the institute the user is associated with.",
+            "type": "string",
+            "pattern": "^(\\S+(\\s|\\S)*\\S+|\\S)$|^$"
+        },
         "submits_for": {
             "title": "Submits for",
             "description": "The labs that the user is authorized to submit data for.",

--- a/src/encoded/static/components/biosample.js
+++ b/src/encoded/static/components/biosample.js
@@ -118,13 +118,6 @@ class BiosampleComponent extends React.Component {
                                         <dd>{context.fixed}</dd>
                                     </div>
                                 : null}
-
-                                {context.donors ?
-                                    <div data-test="donors">
-                                        <dt>Donors</dt>
-                                        <dd>{context.donors}</dd>
-                                    </div>
-                                : null}
                             </dl>
                         </div>
 

--- a/src/encoded/static/components/publication.js
+++ b/src/encoded/static/components/publication.js
@@ -253,10 +253,17 @@ const Abstract = (props) => {
                 </div>
             : null}
 
-            {context.identifiers && context.identifiers.length > 0 ?
-                <div data-test="references">
-                    <dt>References</dt>
-                    <dd><DbxrefList context={context} dbxrefs={context.identifiers} addClasses="multi-value" /></dd>
+            {context.doi ?
+                <div data-test="doireference">
+                    <dt>DOI</dt>
+                    <dd><a href={'https://doi.org/doi:'.concat(context.doi)}>{context.doi}</a></dd>
+                </div>
+            : null}
+
+            {context.pmid ?
+                <div data-test="pmreference">
+                    <dt>PubMed ID</dt>
+                    <dd><a href={'https://www.ncbi.nlm.nih.gov/pubmed/?term='.concat(context.pmid)}>{context.pmid}</a></dd>
                 </div>
             : null}
         </dl>

--- a/src/encoded/tests/data/inserts/cell_annotation.json
+++ b/src/encoded/tests/data/inserts/cell_annotation.json
@@ -15,7 +15,10 @@
             "LATDF119AAA"
         ],
         "annotation_method": "Seurat FindMarkers v3.0.2, manual curation",
-        "notes": "proximal_tubule"
+        "notes": "proximal_tubule",
+        "aliases": [
+            "lattice:special_cell_type"
+        ]
     },
     {
         "uuid": "4c571596-2b0e-41f6-aaf2-950abfd04f58",

--- a/src/encoded/tests/data/inserts/dataset.json
+++ b/src/encoded/tests/data/inserts/dataset.json
@@ -14,13 +14,23 @@
         "references": [
             "lattice:Greka_Clark_2019_large_dataset"
         ],
-        "corresponding_contributor": "abbeclarke@broadinstitute.org",
+        "contributors": [
+            "jimmie.ye@ucsf.ude",
+            "netus.lorem@risus.lobortis"
+        ],
+        "corresponding_contributors": [
+            "abbeclarke@broadinstitute.org"
+        ],
         "dbxrefs": [
             "SRA:SRP492949",
             "ENA:PRJEB37165"
         ],
         "documents": [
             "anna-greka:LID48879"
+        ],
+        "funding_organizations": [
+            "National Institutes of Health",
+            "Chan Zuckerberg Institute"
         ]
     },
     {
@@ -44,7 +54,12 @@
         "references": [
             "lattice:Ye_Chen_2018_atac"
         ],
-        "corresponding_contributor": "jimmie.ye@ucsf.ude",
+        "contributors": [
+            "abbeclarke@broadinstitute.org"
+        ],
+        "corresponding_contributors": [
+            "jimmie.ye@ucsf.ude"
+        ],
         "internal_contact": "r.gate@ucsf.ude",
         "urls": [
             "https://data.humancellatlas.org/explore/projects/4a95101c-9ffc-4f30-a809-f04518a23803"
@@ -68,7 +83,9 @@
         "submitted_by": "jychien@stanford.edu",
         "date_released": "2020-08-07",
         "status": "released",
-        "corresponding_contributor": "pas2182@columbia.ude",
+        "corresponding_contributors": [
+            "pas2182@columbia.ude"
+        ],
         "internal_contact": "cd3403@columbia.ude",
         "references": [
             "52e85c70-fe2d-11e3-9191-0800200c9a66"
@@ -95,7 +112,9 @@
         "submitted_by": "jychien@stanford.edu",
         "date_released": "2020-08-07",
         "status": "deleted",
-        "corresponding_contributor": "netus.lorem@risus.lobortis",
+        "corresponding_contributors": [
+            "netus.lorem@risus.lobortis"
+        ],
         "internal_contact": "netus.lorem@risus.lobortis",
         "references": [
             "474461bd-943e-4514-92a7-e268390eef53"

--- a/src/encoded/tests/data/inserts/dataset.json
+++ b/src/encoded/tests/data/inserts/dataset.json
@@ -3,6 +3,7 @@
         "aliases": [
             "anna-greka:large_test_dataset"
         ],
+        "dataset_title": "The best dataset around",
         "description": "Human, mouse, and CITEseq large dataset",
         "accession": "LATDS700BBB",
         "uuid": "062a566c-89f9-4d23-b0a5-aa38026fb37e",

--- a/src/encoded/tests/data/inserts/matrix_file.json
+++ b/src/encoded/tests/data/inserts/matrix_file.json
@@ -7354,6 +7354,7 @@
         "software": [
             "cellranger aggr 4.0"
         ],
+        "experimental_variable_disease": "MONDO_0005148",
         "md5sum": "2e883306013203954eb1b69ae063eef1",
         "cell_label_location": "suffix",
         "cell_label_mappings": [
@@ -7408,7 +7409,7 @@
                     },
                     {
                         "cutoff_value": 10,
-                        "cutoff_units": "percent mitochondrial/cell",
+                        "cutoff_units": "percent fragments in peaks/nuclei",
                         "cutoff_type": "maximum"
                     },
                     {

--- a/src/encoded/tests/data/inserts/organism.json
+++ b/src/encoded/tests/data/inserts/organism.json
@@ -2,63 +2,63 @@
     {
         "name": "human",
         "scientific_name": "Homo sapiens",
-        "taxon_id": "NCBI:9606",
+        "taxon_id": "NCBITaxon:9606",
         "uuid": "7745b647-ff15-4ff3-9ced-b897d4e2983c",
         "status": "released"
     },
     {
         "name": "rabbit",
         "scientific_name": "Oryctolagus cuniculus",
-        "taxon_id": "NCBI:9986",
+        "taxon_id": "NCBITaxon:9986",
         "uuid": "4f98fd6a-0e61-4988-9032-a5116f6d0607",
         "status": "released"
     },
     {
         "name": "rat",
         "scientific_name": "Rattus norvegicus",
-        "taxon_id": "NCBI:10116",
+        "taxon_id": "NCBITaxon:10116",
         "uuid": "3aa8d64b-dc44-48b5-926d-60ad2befebe7",
         "status": "released"
     },
     {
         "name": "mouse",
         "scientific_name": "Mus musculus",
-        "taxon_id": "NCBI:10090",
+        "taxon_id": "NCBITaxon:10090",
         "uuid": "3413218c-3d86-498b-a0a2-9a406638e786",
         "status": "released"
     },
     {
         "name": "sheep",
         "scientific_name": "Ovis aries",
-        "taxon_id": "NCBI:9940",
+        "taxon_id": "NCBITaxon:9940",
         "uuid": "2cfcb093-0619-4e52-b6d5-15779860dc49",
         "status": "released"
     },
     {
         "name": "goat",
         "scientific_name": "Capra hircus",
-        "taxon_id": "NCBI:9925",
+        "taxon_id": "NCBITaxon:9925",
         "uuid": "3e4d691d-49b0-40bd-9628-bb4f53d80980",
         "status": "released"
     },
     {
         "name": "chicken",
         "scientific_name": "Gallus gallus",
-        "taxon_id": "NCBI:9031",
+        "taxon_id": "NCBITaxon:9031",
         "uuid": "c3aff9e7-8460-44b7-8cc2-ed9cade08ead",
         "status": "released"
     },
     {
         "name": "dmelanogaster",
         "scientific_name": "Drosophila melanogaster",
-        "taxon_id": "NCBI:7227",
+        "taxon_id": "NCBITaxon:7227",
         "uuid": "ab546d43-8e2a-4567-8db7-a217e6d6eea0",
         "status": "released"
     },
     {
         "name": "celegans",
         "scientific_name": "Caenorhabditis elegans",
-        "taxon_id": "NCBI:6239",
+        "taxon_id": "NCBITaxon:6239",
         "uuid": "2732dfd9-4fe6-4fd2-9d88-61b7c58cbe20",
         "status": "released"
     },
@@ -66,97 +66,97 @@
     {
         "name": "cbrenneri",
         "scientific_name": "Caenorhabditis brenneri",
-        "taxon_id": "NCBI:135651",
+        "taxon_id": "NCBITaxon:135651",
         "uuid": "e3ec4c1b-a203-4fe7-a013-96c2d45ab242",
         "status": "released"
     },
     {
         "name": "cbriggsae",
         "scientific_name": "Caenorhabditis briggsae",
-        "taxon_id": "NCBI:6238",
+        "taxon_id": "NCBITaxon:6238",
         "uuid": "69efae2b-4df5-4957-81da-346f1b93cb98",
         "status": "released"
     },
     {
         "name": "cjaponica",
         "scientific_name": "Caenorhabditis japonica",
-        "taxon_id": "NCBI:281687",
+        "taxon_id": "NCBITaxon:281687",
         "uuid": "a7e711b9-534c-44a3-a782-2a15af620739",
         "status": "released"
     },
     {
         "name": "cremanei",
         "scientific_name": "Caenorhabditis remanei",
-        "taxon_id": "NCBI:31234",
+        "taxon_id": "NCBITaxon:31234",
         "uuid": "451f9e49-685d-40d5-ad89-760b2512262a",
         "status": "released"
     },
     {
         "name": "dananassae",
         "scientific_name": "Drosophila ananassae",
-        "taxon_id": "NCBI:7217",
+        "taxon_id": "NCBITaxon:7217",
         "uuid": "5be68469-94ba-4d60-b361-dde8958399ca",
         "status": "released"
     },
     {
         "name": "dmojavensis",
         "scientific_name": "Drosophila mojavensis",
-        "taxon_id": "NCBI:7230",
+        "taxon_id": "NCBITaxon:7230",
         "uuid": "74144f1f-f3a6-42b9-abfd-186a1ca93198",
         "status": "released"
     },
     {
         "name": "dpseudoobscura",
         "scientific_name": "Drosophila pseudoobscura",
-        "taxon_id": "NCBI:7237",
+        "taxon_id": "NCBITaxon:7237",
         "uuid": "c3cc08b7-7814-4cae-a363-a16b76883e3f",
         "status": "released"
     },
     {
         "name": "dsimulans",
         "scientific_name": "Drosophila simulans",
-        "taxon_id": "NCBI:7240",
+        "taxon_id": "NCBITaxon:7240",
         "uuid": "d1072fd2-8374-4f9b-85ce-8bc2c61de122",
         "status": "released"
     },
     {
         "name": "dvirilis",
         "scientific_name": "Drosophila virilis",
-        "taxon_id": "NCBI:7244",
+        "taxon_id": "NCBITaxon:7244",
         "uuid": "b9ce90a4-b791-40e9-9b4d-ffb1c6a5aa2b",
         "status": "released"
     },
     {
         "name": "dyakuba",
         "scientific_name": "Drosophila yakuba",
-        "taxon_id": "NCBI:7245",
+        "taxon_id": "NCBITaxon:7245",
         "uuid": "0bdd955a-57f0-4e4b-b93d-6dd1df9b766c",
         "status": "released"
     },
     {
         "name": "avictoria",
         "scientific_name": "Aequorea victoria",
-        "taxon_id": "NCBI:6100",
+        "taxon_id": "NCBITaxon:6100",
         "uuid": "2ca583ff-71b8-4cf8-bfe3-392b7ddd28a2",
         "status": "released"
     },
     {
         "name": "synthetic",
         "scientific_name": "synthetic",
-        "taxon_id": "NCBI:0",
+        "taxon_id": "NCBITaxon:0",
         "uuid": "5d8f172c-2220-4d76-89e2-e26ed08c42e8",
         "status": "released"
     },
     {
         "name": "influenza",
-        "taxon_id": "NCBI:11309",
+        "taxon_id": "NCBITaxon:11309",
         "scientific_name": "influenzavirus",
         "uuid": "7349d69e-04f3-4650-b2c8-963cce2341d6",
         "status": "released"
     },
     {
         "name": "bacteriophage-t7",
-        "taxon_id": "NCBI:10760",
+        "taxon_id": "NCBITaxon:10760",
         "scientific_name": "enterobacteria phage t7",
         "uuid": "e426f5b3-e577-4afb-8bb5-ce57a6d4d050",
         "status": "released"

--- a/src/encoded/tests/data/inserts/publication.json
+++ b/src/encoded/tests/data/inserts/publication.json
@@ -9,9 +9,7 @@
         "authors": "Anna Greka, Abbe Clark",
         "journal": "BMC Bioinformatics",
         "publication_year": 2019,
-        "identifiers": [
-            "PMID:2314242"
-        ],
+        "pmid": "2314242",
         "award": "CZI001KID",
         "volume": "88",
         "page": "55-57",
@@ -26,10 +24,8 @@
         "authors": "Jimmie Ye, Jenny Chen",
         "journal": "Nature",
         "publication_year": 2018,
-        "identifiers": [
-            "PMID:22955622",
-            "doi:10.1101/2020.07.24.219147"
-        ],
+        "pmid": "22955622",
+        "doi": "10.1101/2020.07.24.219147",
         "award": "CZI021IMM",
         "volume": "234",
         "issue": "454",
@@ -47,10 +43,8 @@
         "journal": "Nature",
         "award": "CZI004LIV",
         "publication_year": 2012,
-        "identifiers": [
-            "PMID:22955616",
-            "doi:10.1016/j.devcel.2020.01.033"
-        ],
+        "pmid": "22955616",
+        "doi": "10.1016/j.devcel.2020.01.033",
         "volume": "489",
         "issue": "7414",
         "page": "57-74",
@@ -70,10 +64,8 @@
         "page": "pdb.prot5384",
         "volume": "2010",
         "publication_year": 2020,
-        "identifiers": [
-            "PMID:20150888",
-            "doi:10.1016/j.devcel.2020.07.023"
-        ],
+        "pmid": "20150888",
+        "doi": "10.1016/j.devcel.2020.07.023",
         "award": "CZI025LYN",
         "authors": "Livnat Jerby-Arnon, Aviv Regev"
     }

--- a/src/encoded/tests/data/inserts/raw_sequence_file.json
+++ b/src/encoded/tests/data/inserts/raw_sequence_file.json
@@ -20,6 +20,9 @@
         "read_length": 8,
         "read_count": 1000000,
         "derived_from": ["2a12eb7b-ed78-466a-9552-7512bdd7f45f"],
+        "derivation_process": [
+            "demultiplexing"
+        ],
         "md5sum": "fc33724fb1dc16163432e7bd6bf6d4ed",
         "s3_uri": "s3://submissions-lattice/fastq/19D014_per_I1_sample.fastq.gz",
         "validated": true

--- a/src/encoded/tests/data/inserts/user.json
+++ b/src/encoded/tests/data/inserts/user.json
@@ -12,7 +12,8 @@
             "community",
             "CZI001KID"
         ],
-        "uuid": "58b5c2f0-d147-4c17-bf38-a142e2234488"
+        "uuid": "58b5c2f0-d147-4c17-bf38-a142e2234488",
+        "institute_name": "Stanford University"
     },
     {
         "email": "agreka@bwh.harvard.ude",
@@ -27,7 +28,8 @@
             "community",
             "CZI001KID"
         ],
-        "uuid": "bcee0c61-2216-45a0-b839-1dd832ec220c"
+        "uuid": "bcee0c61-2216-45a0-b839-1dd832ec220c",
+        "institute_name": "Harvard"
     },
     {
         "email": "jpa29@stanford.edu",
@@ -38,7 +40,8 @@
         "groups": [
             "admin"
         ],
-        "uuid": "294a192a-f01e-42d7-b579-192790f96a8f"
+        "uuid": "294a192a-f01e-42d7-b579-192790f96a8f",
+        "institute_name": "Stanford University"
     },
     {
         "email": "jimmie.ye@ucsf.ude",
@@ -52,7 +55,8 @@
         "viewing_groups": [
             "community"
         ],
-        "uuid": "d162af00-38d0-4b02-a319-fcaf76a479d2"
+        "uuid": "d162af00-38d0-4b02-a319-fcaf76a479d2",
+        "institute_name": "UC San Fran"
     },
     {
         "email": "r.gate@ucsf.ude",
@@ -66,7 +70,8 @@
         "viewing_groups": [
             "community"
         ],
-        "uuid": "54d092c3-b7ab-49f4-a2bb-00eeebc8e440"
+        "uuid": "54d092c3-b7ab-49f4-a2bb-00eeebc8e440",
+        "institute_name": "Stanford University"
     },
     {
         "email": "pas2182@columbia.ude",
@@ -80,7 +85,8 @@
         "viewing_groups": [
             "community"
         ],
-        "uuid": "ccdf34b7-a013-4056-90bd-5a934cc2c118"
+        "uuid": "ccdf34b7-a013-4056-90bd-5a934cc2c118",
+        "institute_name": "Stanford University"
     },
     {
         "email": "cd3403@columbia.ude",
@@ -94,7 +100,8 @@
         "viewing_groups": [
             "community"
         ],
-        "uuid": "b88b4a37-01c6-45b6-b0ba-f51b37947faa"
+        "uuid": "b88b4a37-01c6-45b6-b0ba-f51b37947faa",
+        "institute_name": "Stanford University"
     },
     {
         "email": "jahilton@stanford.edu",
@@ -221,6 +228,7 @@
         "lab": "/labs/j-michael-cherry/",
         "last_name": "Hill",
         "status": "current",
-        "uuid": "cd09e34b-7513-456c-a69c-66d258b99d83"
+        "uuid": "cd09e34b-7513-456c-a69c-66d258b99d83",
+        "institute_name": "Clown University"
     }
 ]

--- a/src/encoded/tests/test_permissions.py
+++ b/src/encoded/tests/test_permissions.py
@@ -88,7 +88,6 @@ def test_users_post_disallowed(submitter, access_key, submitter_testapp):
 def test_users_view_basic_indexer(submitter, indexer_testapp):
     res = indexer_testapp.get(submitter['@id'])
     assert 'title' in res.json
-    assert 'email' not in res.json
     assert 'access_keys' not in res.json
 
 

--- a/src/encoded/tests/test_upgrade_dataset.py
+++ b/src/encoded/tests/test_upgrade_dataset.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+def test_dataset_upgrade_1_2(upgrader, dataset_base):
+	dataset_base['corresponding_contributor'] = '62ba2fba-8ee9-4996-b804-f9a673d137c3'
+	value = upgrader.upgrade('dataset', dataset_base, current_version='1', target_version='2')
+	assert 'corresponding_contributor' not in value
+	assert value['corresponding_contributors'] == ['62ba2fba-8ee9-4996-b804-f9a673d137c3']
+	assert value['schema_version'] == '2'

--- a/src/encoded/tests/test_upgrade_organism.py
+++ b/src/encoded/tests/test_upgrade_organism.py
@@ -7,3 +7,10 @@ def test_organism_upgrade_1_2(upgrader, human):
 	assert value['schema_version'] == '2'
 	assert value['taxon_id'] == 'NCBI:9606'
 	assert 'ncbi_taxon_id' not in value
+
+
+def test_organism_upgrade_2_3(upgrader, human):
+	human['taxon_id'] = 'NCBI:9606'
+	value = upgrader.upgrade('organism', human, current_version='2', target_version='3')
+	assert value['schema_version'] == '3'
+	assert value['taxon_id'] == 'NCBITaxon:9606'

--- a/src/encoded/tests/test_upgrade_publication.py
+++ b/src/encoded/tests/test_upgrade_publication.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def test_publication_upgrade_1_2(upgrader, publication_base):
+	publication_base['identifiers'] = ['doi:10.1101/2020.06.25.171793', 'PMID:234523']
+	value = upgrader.upgrade('publication', publication_base, current_version='1', target_version='2')
+	assert 'identifiers' not in value
+	assert value['schema_version'] == '2'
+	assert value['doi'] == '10.1101/2020.06.25.171793'
+	assert value['pmid'] == '234523'

--- a/src/encoded/types/__init__.py
+++ b/src/encoded/types/__init__.py
@@ -66,17 +66,6 @@ class Organism(Item):
 
 
 @collection(
-    name='treatments',
-    properties={
-        'title': 'Treatments',
-        'description': 'Listing Biosample Treatments',
-    })
-class Treatment(Item):
-    item_type = 'treatment'
-    schema = load_schema('encoded:schemas/treatment.json')
-
-
-@collection(
     name='documents',
     properties={
         'title': 'Documents',

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -12,6 +12,16 @@ from .shared_calculated_properties import (
 )
 
 
+def pluralize(value, value_units):
+    try:
+        if float(value) == 1:
+            return str(value) + ' ' + value_units
+        else:
+            return str(value) + ' ' + value_units + 's'
+    except:
+        return str(value) + ' ' + value_units + 's'
+
+
 @abstract_collection(
     name='biosamples',
     unique_key='accession',
@@ -47,14 +57,15 @@ class Biosample(Item, CalculatedDonors):
                     amt = str(t_obj['amount'])
                     if amt.endswith('.0'):
                         amt = amt[:-2]
-                    summ += (amt + ' ' + t_obj['amount_units'] + ' of ')
+                    a_units = t_obj['amount_units']
+                    summ += (amt + ' ' + a_units + ' of ')
                 summ += (t_obj.get('treatment_term_name'))
 
                 if t_obj.get('duration'):
                     d = str(t_obj['duration'])
                     if d.endswith('.0'):
                         d = d[:-2]
-                    dur = d + ' ' + t_obj['duration_units']
+                    dur = pluralize(d, t_obj['duration_units'])
                 else:
                     dur = 'none'
 

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -25,8 +25,54 @@ class Biosample(Item, CalculatedDonors):
     rev = {}
     embedded = [
         'biosample_ontology',
-        'diseases'
+        'diseases',
+        'donors',
+        'donors.organism'
     ]
+
+    @calculated_property(schema={
+        "title": "Treatment summary",
+        "description": "A summary of the treatments applied to the Biosample.",
+        "comment": "Do not submit. This is a calculated property",
+        "type": "string",
+        "notSubmittable": True,
+    })
+    def treatment_summary(self, request, treatments=None):
+        if treatments:
+            dur_dict = {}
+            for t in treatments:
+                t_obj = request.embed(t, '@@object?skip_calculated=true')
+                summ = ''
+                if t_obj.get('amount'):
+                    amt = str(t_obj['amount'])
+                    if amt.endswith('.0'):
+                        amt = amt[:-2]
+                    summ += (amt + ' ' + t_obj['amount_units'] + ' of ')
+                summ += (t_obj.get('treatment_term_name'))
+
+                if t_obj.get('duration'):
+                    d = str(t_obj['duration'])
+                    if d.endswith('.0'):
+                        d = d[:-2]
+                    dur = d + ' ' + t_obj['duration_units']
+                else:
+                    dur = 'none'
+
+                if dur_dict.get(dur):
+                    if t_obj.get('amount'):
+                        dur_dict[dur].append(summ)
+                    else:
+                        dur_dict[dur].insert(0, summ)
+                else:
+                    dur_dict[dur] = [summ]
+
+            ovr = []
+            for k,v in dur_dict.items():
+                temp = (' and '.join(v))
+                if k != 'none':
+                    temp += (' for ' + k)
+                ovr.append(temp)
+            return ('; '.join(ovr))
 
 
 @abstract_collection(

--- a/src/encoded/types/dataset.py
+++ b/src/encoded/types/dataset.py
@@ -40,7 +40,9 @@ class Dataset(Item):
         'libraries',
         'libraries.protocol',
         'award',
-        'references'
+        'references',
+        'corresponding_contributors',
+        'contributors'
     ]
     rev = {
         'superseded_by': ('Dataset', 'supersedes'),

--- a/src/encoded/types/donor.py
+++ b/src/encoded/types/donor.py
@@ -20,6 +20,7 @@ from .base import (
 class Donor(Item):
     base_types = ['Donor'] + Item.base_types
     embedded = [
+        'diseases',
         'organism'
     ]
     name_key = 'accession'

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -254,7 +254,7 @@ class SequenceAlignmentFile(AnalysisFile):
 class RawSequenceFile(DataFile):
     item_type = 'raw_sequence_file'
     schema = load_schema('encoded:schemas/raw_sequence_file.json')
-    embedded = DataFile.embedded + []
+    embedded = DataFile.embedded + ['derived_from', 'derived_from.flowcell_details']
 
     @calculated_property(define=True,
                          schema={"title": "Libraries",

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -306,7 +306,7 @@ class RawSequenceFile(DataFile):
 class MatrixFile(AnalysisFile):
     item_type = 'matrix_file'
     schema = load_schema('encoded:schemas/matrix_file.json')
-    embedded = AnalysisFile.embedded + ['cell_annotations', 'cell_annotations.cell_ontology']
+    embedded = AnalysisFile.embedded + ['cell_annotations', 'cell_annotations.cell_ontology', 'experimental_variable_disease']
     rev = {
         'cell_annotations': ('CellAnnotation', 'matrix_files'),
         'quality_metrics': ('Metrics', 'quality_metric_of')

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -331,6 +331,24 @@ class MatrixFile(AnalysisFile):
 
 
     @calculated_property(schema={
+        "title": "Assays",
+        "description": "The list of assays used to generate data contained in this matrix.",
+        "comment": "Do not submit. Values in the list are reverse links of a quality metric with this file in quality_metric_of field.",
+        "type": "array",
+        "items": {
+            "type": 'string'
+        },
+        "notSubmittable": True,
+    })
+    def assays(self, request, libraries=None):
+        assays = set()
+        for l in libraries:
+            l_obj = request.embed(l, '@@object')
+            assays.add(l_obj['assay'])
+        return assays
+
+
+    @calculated_property(schema={
         "title": "Cell annotations",
         "description": "The cell annotations applied to this matrix.",
         "comment": "Do not submit. This is a calculated property",

--- a/src/encoded/types/library.py
+++ b/src/encoded/types/library.py
@@ -43,7 +43,6 @@ class Library(Item, CalculatedAward, CalculatedBiosampleOntologies):
         "comment": "Do not submit. This is a calculated property",
         "type": "string",
         "enum": [
-            "scATAC-seq",
             "snATAC-seq",
             "scRNA-seq",
             "snRNA-seq",

--- a/src/encoded/types/suspension.py
+++ b/src/encoded/types/suspension.py
@@ -23,5 +23,7 @@ class Suspension(Item, CalculatedDonors, CalculatedBiosampleOntologies):
     item_type = 'suspension'
     schema = load_schema('encoded:schemas/suspension.json')
     embedded = [
-        'biosample_ontologies'
+        'biosample_ontologies',
+        'donors',
+        'donors.organism'
     ]

--- a/src/encoded/types/treatment.py
+++ b/src/encoded/types/treatment.py
@@ -8,6 +8,16 @@ from .base import (
 )
 
 
+def pluralize(value, value_units):
+    try:
+        if float(value) == 1:
+            return str(value) + ' ' + value_units
+        else:
+            return str(value) + ' ' + value_units + 's'
+    except:
+        return str(value) + ' ' + value_units + 's'
+
+
 @collection(
     name='treatments',
     properties={
@@ -30,13 +40,22 @@ class Treatment(Item):
             amount=None, amount_units=None, temperature=None, temperature_units=None):
         summ = []
         if amount:
-            amt = '{} {} of'.format(amount, amount_units)
+            a = str(amount)
+            if a.endswith('.0'):
+                a = a[:-2]
+            amt = '{} {} of'.format(a, amount_units)
             summ.append(amt)
         summ.append(treatment_term_name)
         if duration:
-            dur = 'for {} {}'.format(duration, duration_units)
+            d = str(duration)
+            if d.endswith('.0'):
+                d = d[:-2]
+            dur = 'for {}'.format(pluralize(d, duration_units))
             summ.append(dur)
         if temperature:
-            temp = 'at {} {}'.format(temperature, temperature_units)
+            t = str(temperature)
+            if t.endswith('.0'):
+                t = t[:-2]
+            temp = 'at {} {}'.format(t, temperature_units)
             summ.append(temp)
         return ' '.join(summ)

--- a/src/encoded/types/treatment.py
+++ b/src/encoded/types/treatment.py
@@ -1,0 +1,42 @@
+from snovault import (
+    calculated_property,
+    collection,
+    load_schema,
+)
+from .base import (
+    Item,
+)
+
+
+@collection(
+    name='treatments',
+    properties={
+        'title': 'Treatments',
+        'description': 'Listing Biosample Treatments',
+    })
+class Treatment(Item):
+    item_type = 'treatment'
+    schema = load_schema('encoded:schemas/treatment.json')
+
+
+    @calculated_property(schema={
+        "title": "Summary",
+        "description": "A summary of the treatment.",
+        "comment": "Do not submit. This is a calculated property",
+        "type": "string",
+        "notSubmittable": True,
+    })
+    def summary(self, request, treatment_term_name, duration=None, duration_units=None,
+            amount=None, amount_units=None, temperature=None, temperature_units=None):
+        summ = []
+        if amount:
+            amt = '{} {} of'.format(amount, amount_units)
+            summ.append(amt)
+        summ.append(treatment_term_name)
+        if duration:
+            dur = 'for {} {}'.format(duration, duration_units)
+            summ.append(dur)
+        if temperature:
+            temp = 'at {} {}'.format(temperature, temperature_units)
+            summ.append(temp)
+        return ' '.join(summ)

--- a/src/encoded/types/user.py
+++ b/src/encoded/types/user.py
@@ -100,7 +100,7 @@ def user_page_view(context, request):
 def user_basic_view(context, request):
     properties = item_view_object(context, request)
     filtered = {}
-    for key in ['@id', '@type', 'uuid', 'lab', 'title', 'submits_for', 'institute_name']:
+    for key in ['@id', '@type', 'uuid', 'lab', 'title', 'submits_for', 'institute_name', 'email']:
         try:
             filtered[key] = properties[key]
         except KeyError:

--- a/src/encoded/types/user.py
+++ b/src/encoded/types/user.py
@@ -100,7 +100,7 @@ def user_page_view(context, request):
 def user_basic_view(context, request):
     properties = item_view_object(context, request)
     filtered = {}
-    for key in ['@id', '@type', 'uuid', 'lab', 'title', 'submits_for']:
+    for key in ['@id', '@type', 'uuid', 'lab', 'title', 'submits_for', 'institute_name']:
         try:
             filtered[key] = properties[key]
         except KeyError:

--- a/src/encoded/upgrade/dataset.py
+++ b/src/encoded/upgrade/dataset.py
@@ -1,0 +1,8 @@
+from snovault import upgrade_step
+
+
+@upgrade_step('dataset', '1', '2')
+def dataset_1_2(value, system):
+	if 'corresponding_contributor' in value:
+		value['corresponding_contributors'] = [value['corresponding_contributor']]
+		del value['corresponding_contributor']

--- a/src/encoded/upgrade/organism.py
+++ b/src/encoded/upgrade/organism.py
@@ -5,3 +5,11 @@ from snovault import upgrade_step
 def organism_1_2(value, system):
     value['taxon_id'] = 'NCBI:' + value['ncbi_taxon_id']
     del value['ncbi_taxon_id']
+
+
+
+@upgrade_step('organism', '2', '3')
+def organism_2_3(value, system):
+    if 'taxon_id' in value:
+    	path = value['taxon_id'].split(':')
+    	value['taxon_id'] = 'NCBITaxon:' + path[1]

--- a/src/encoded/upgrade/publication.py
+++ b/src/encoded/upgrade/publication.py
@@ -1,0 +1,13 @@
+from snovault import upgrade_step
+
+
+@upgrade_step('publication', '1', '2')
+def publication_1_2(value, system):
+	if 'identifiers' in value:
+		for i in value['identifiers']:
+			path = i.split(':')
+			if path[0] == 'doi':
+				value['doi'] = path[1]
+			elif path[0] == 'PMID':
+				value['pmid'] = path[1]
+		del value['identifiers']


### PR DESCRIPTION
Many changes towards adding embedded fields to more easily extract metadata for DCP & cellxgene outputs
Adding fields for DCP - dataset_title, contributors, corresponding_contributors, pmid, doi, funders
Added treatment summary fields on Treatment & Biosamples
Other smaller updates noted in the ticket
