### PR TITLE
summary-view

### DIFF
--- a/src/encoded/schemas/award.json
+++ b/src/encoded/schemas/award.json
@@ -47,6 +47,12 @@
                 "linkTo": "User"
             }
         },
+        "coordinating_pi": {
+            "title": "Coordinating PI",
+            "description": "Coordinating PI of the grant.",
+            "type": "string",
+            "linkTo": "User"
+        },
         "collaborators": {
             "title": "Collaborators",
             "description": "Collaborators of the grant.",

--- a/src/encoded/schemas/dataset.json
+++ b/src/encoded/schemas/dataset.json
@@ -126,6 +126,9 @@
         "award.project": {
             "title": "Project"
         },
+        "award.coordinating_pi.title": {
+            "title": "Coordinating PI"
+        },
         "award.name": {
             "title": "Award name"
         },
@@ -151,6 +154,9 @@
         },
         "award.name": {
             "title": "Award name"
+        },
+        "award.coordinating_pi.title": {
+            "title": "Coordinating PI"
         },
         "references.citation": {
             "title": "References"

--- a/src/encoded/schemas/library.json
+++ b/src/encoded/schemas/library.json
@@ -218,6 +218,9 @@
         "award.project": {
             "title": "Project"
         },
+        "award.coordinating_pi.title": {
+            "title": "Coordinating PI"
+        },
         "award.name": {
             "title": "Award name"
         },
@@ -278,6 +281,9 @@
         },
         "award.name": {
             "title": "Award name"
+        },
+        "award.coordinating_pi.title": {
+            "title": "Coordinating PI"
         },
         "lab.title": {
             "title": "Lab"

--- a/src/encoded/search_views.py
+++ b/src/encoded/search_views.py
@@ -2,7 +2,12 @@ from pyramid.view import view_config
 
 from snovault.elasticsearch.searches.interfaces import REPORT_TITLE
 from snovault.elasticsearch.searches.interfaces import SEARCH_TITLE
+from snovault.elasticsearch.searches.interfaces import SUMMARY_MATRIX
+from snovault.elasticsearch.searches.interfaces import SUMMARY_TITLE
+from snovault.elasticsearch.searches.interfaces import MATRIX_TITLE
 from snovault.elasticsearch.searches.fields import AllResponseField
+from snovault.elasticsearch.searches.fields import BasicMatrixWithFacetsResponseField
+from snovault.elasticsearch.searches.fields import MissingMatrixWithFacetsResponseField
 from snovault.elasticsearch.searches.fields import BasicSearchResponseField
 from snovault.elasticsearch.searches.fields import BasicSearchWithFacetsResponseField
 from snovault.elasticsearch.searches.fields import BasicReportWithFacetsResponseField
@@ -14,6 +19,7 @@ from snovault.elasticsearch.searches.fields import FiltersResponseField
 from snovault.elasticsearch.searches.fields import IDResponseField
 from snovault.elasticsearch.searches.fields import NotificationResponseField
 from snovault.elasticsearch.searches.fields import NonSortableResponseField
+from snovault.elasticsearch.searches.fields import RawMatrixWithAggsResponseField
 from snovault.elasticsearch.searches.fields import RawSearchWithAggsResponseField
 from snovault.elasticsearch.searches.fields import SearchBaseResponseField
 from snovault.elasticsearch.searches.fields import SortResponseField
@@ -30,6 +36,9 @@ def includeme(config):
     config.add_route('searchv2_raw', '/searchv2_raw{slash:/?}')
     config.add_route('searchv2_quick', '/searchv2_quick{slash:/?}')
     config.add_route('report', '/report{slash:/?}')
+    config.add_route('matrixv2_raw', '/matrixv2_raw{slash:/?}')
+    config.add_route('matrix', '/matrix{slash:/?}')
+    config.add_route('summary', '/summary{slash:/?}')
     config.scan(__name__)
 
 
@@ -149,6 +158,78 @@ def report(context, request):
             ColumnsResponseField(),
             NonSortableResponseField(),
             SortResponseField(),
+            DebugQueryResponseField()
+        ]
+    )
+    return fr.render()
+
+
+@view_config(route_name='matrixv2_raw', request_method='GET', permission='search')
+def matrixv2_raw(context, request):
+    fr = FieldedResponse(
+        _meta={
+            'params_parser': ParamsParser(request)
+        },
+        response_fields=[
+            RawMatrixWithAggsResponseField(
+                default_item_types=DEFAULT_ITEM_TYPES
+            )
+        ]
+    )
+    return fr.render()
+
+
+@view_config(route_name='matrix', request_method='GET', permission='search')
+def matrix(context, request):
+    fr = FieldedResponse(
+        _meta={
+            'params_parser': ParamsParser(request)
+        },
+        response_fields=[
+            TitleResponseField(
+                title=MATRIX_TITLE
+            ),
+            TypeResponseField(
+                at_type=[MATRIX_TITLE]
+            ),
+            IDResponseField(),
+            SearchBaseResponseField(),
+            ContextResponseField(),
+            BasicMatrixWithFacetsResponseField(
+                default_item_types=DEFAULT_ITEM_TYPES
+            ),
+            NotificationResponseField(),
+            FiltersResponseField(),
+            TypeOnlyClearFiltersResponseField(),
+            DebugQueryResponseField()
+        ]
+    )
+    return fr.render()
+
+
+@view_config(route_name='summary', request_method='GET', permission='search')
+def summary(context, request):
+    fr = FieldedResponse(
+        _meta={
+            'params_parser': ParamsParser(request)
+        },
+        response_fields=[
+            TitleResponseField(
+                title=SUMMARY_TITLE
+            ),
+            TypeResponseField(
+                at_type=[SUMMARY_TITLE]
+            ),
+            IDResponseField(),
+            SearchBaseResponseField(),
+            ContextResponseField(),
+            BasicMatrixWithFacetsResponseField(
+                default_item_types=DEFAULT_ITEM_TYPES,
+                matrix_definition_name=SUMMARY_MATRIX
+            ),
+            NotificationResponseField(),
+            FiltersResponseField(),
+            TypeOnlyClearFiltersResponseField(),
             DebugQueryResponseField()
         ]
     )

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -300,7 +300,7 @@ export function createBarChart(chartId, data, colors, replicateLabels, legendTit
     });
 }
 
-export function createNewBarChart(chartId, data, colors, replicateLabels, legendTitle, baseSearchUri, navigate) {
+export function createNewBarChart(chartId, data, colors, replicateLabels, baseSearchUri, navigate) {
     return new Promise((resolve) => {
         require.ensure(['chart.js'], (require) => {
             const Chart = require('chart.js');
@@ -363,30 +363,6 @@ export function createNewBarChart(chartId, data, colors, replicateLabels, legend
                     animation: {
                         duration: 0,
                     },
-                    legendCallback: (chartInstance) => {
-                        const LegendLabels = [];
-                        const dataColors = [];
-                        // If data array has value, add to legend
-                        for (let i = 0; i < chartInstance.data.datasets.length; i += 1) {
-                            LegendLabels.push(chartInstance.data.datasets[i].label);
-                            dataColors.push(chartInstance.data.datasets[i].backgroundColor);
-                        }
-                        const text = [];
-                        if (legendTitle) {
-                            text.push(`<div class="legend-title">${legendTitle}</div>`);
-                        }
-                        text.push('<ul>');
-                        for (let i = 0; i < LegendLabels.length; i += 1) {
-                            if (LegendLabels[i]) {
-                                text.push(`<li><a href="${baseSearchUri}&donors.sex=${LegendLabels[i]}">`);
-                                text.push(`<i class="icon icon-circle chart-legend-chip" aria-hidden="true" style="color:${dataColors[i]}"></i>`);
-                                text.push(`<span class="chart-legend-label">${LegendLabels[i]}</span>`);
-                                text.push('</a></li>');
-                            }
-                        }
-                        text.push('</ul>');
-                        return text.join('');
-                    },
                     onClick: function onClick(e) {
                         const activePoints = chart.getElementAtEvent(e);
 
@@ -413,7 +389,6 @@ export function createNewBarChart(chartId, data, colors, replicateLabels, legend
                     },
                 },
             });
-            document.getElementById(`${chartId}-legend`).innerHTML = chart.generateLegend();
             resolve(chart);
         }, 'chartjs');
     });

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -300,6 +300,124 @@ export function createBarChart(chartId, data, colors, replicateLabels, legendTit
     });
 }
 
+export function createNewBarChart(chartId, data, colors, replicateLabels, legendTitle, baseSearchUri, navigate) {
+    return new Promise((resolve) => {
+        require.ensure(['chart.js'], (require) => {
+            const Chart = require('chart.js');
+            const datasets = [];
+            if (data.unknownDataset.some(x => x > 0)) {
+                datasets.push({ label: 'unknown', data: data.unknownDataset, backgroundColor: colors[0] });
+            }
+            if (data.maleDataset.some(x => x > 0)) {
+                datasets.push({ label: 'male', data: data.maleDataset, backgroundColor: colors[1] });
+            }
+            if (data.femaleDataset.some(x => x > 0)) {
+                datasets.push({ label: 'female', data: data.femaleDataset, backgroundColor: colors[2] });
+            }
+            for (let i = 0; i < datasets.length; i += 1) {
+                datasets[i].backgroundColor = colors[i];
+            }
+
+            // Create the chart.
+            const canvas = document.getElementById(`${chartId}-chart`);
+            const parent = document.getElementById(chartId);
+            canvas.width = parent.offsetWidth;
+            canvas.height = parent.offsetHeight;
+            canvas.style.width = `${parent.offsetWidth}px`;
+            canvas.style.height = `${parent.offsetHeight}px`;
+            const ctx = canvas.getContext('2d');
+            const chart = new Chart(ctx, {
+                type: 'bar',
+                data: {
+                    labels: data.labels,
+                    datasets,
+                },
+                options: {
+                    maintainAspectRatio: false,
+                    responsive: true,
+                    legend: {
+                        display: false,
+                    },
+                    scales: {
+                        xAxes: [{
+                            scaleLabel: {
+                                display: false,
+                            },
+                            gridLines: {
+                            },
+                            stacked: true,
+                            ticks: {
+                                autoSkip: false,
+                            },
+                        }],
+                        yAxes: [{
+                            gridLines: {
+                                display: false,
+                                color: '#fff',
+                                zeroLineColor: '#fff',
+                                zeroLineWidth: 0,
+                            },
+                            stacked: true,
+                        }],
+                    },
+                    animation: {
+                        duration: 0,
+                    },
+                    legendCallback: (chartInstance) => {
+                        const LegendLabels = [];
+                        const dataColors = [];
+                        // If data array has value, add to legend
+                        for (let i = 0; i < chartInstance.data.datasets.length; i += 1) {
+                            LegendLabels.push(chartInstance.data.datasets[i].label);
+                            dataColors.push(chartInstance.data.datasets[i].backgroundColor);
+                        }
+                        const text = [];
+                        if (legendTitle) {
+                            text.push(`<div class="legend-title">${legendTitle}</div>`);
+                        }
+                        text.push('<ul>');
+                        for (let i = 0; i < LegendLabels.length; i += 1) {
+                            if (LegendLabels[i]) {
+                                text.push(`<li><a href="${baseSearchUri}&donors.sex=${LegendLabels[i]}">`);
+                                text.push(`<i class="icon icon-circle chart-legend-chip" aria-hidden="true" style="color:${dataColors[i]}"></i>`);
+                                text.push(`<span class="chart-legend-label">${LegendLabels[i]}</span>`);
+                                text.push('</a></li>');
+                            }
+                        }
+                        text.push('</ul>');
+                        return text.join('');
+                    },
+                    onClick: function onClick(e) {
+                        const activePoints = chart.getElementAtEvent(e);
+
+                        if (activePoints[0]) { // if click on wrong area, do nothing
+                            const clickedElementIndex = activePoints[0]._index;
+                            const clickedElementdataset = activePoints[0]._datasetIndex;
+                            const term = chart.data.labels[clickedElementIndex];
+                            const item = chart.data.datasets[clickedElementdataset].label;
+                            // chart.options.onClick.baseSearchUri is created or altered based on user input of selected Genus Buttons
+                            // Each type of Object (e.g. Experiments, Annotations, Biosample, AntibodyLot) has a unique
+                            //      query string for the corresponding report search -- cannot simply append something
+                            //      to end of baseSearchUri, as baseSearchUri ends with {searchtype}=
+                            //      so, query string specifying genus must end up somewhere in the middle of the string
+                            //      that is baseSearchUri.
+                            // chart.options.onClick.baseSearchUri must be defined in the type of chart (StatusChart, CategoryChart)
+                            //      that is passed to the createDonutChart or createBarChart functions because cannot directly
+                            //      make changes to the param baseSearchUri in updateChart().
+                            if (chart.options.onClick.baseSearchUri) {
+                                navigate(`${chart.options.onClick.baseSearchUri}&donors.ethnicity.term_name=${encoding.encodedURIComponentOLD(term)}&donors.sex=${item}`);
+                            } else {
+                                navigate(`${baseSearchUri}&donors.ethnicity.term_name=${encoding.encodedURIComponentOLD(term)}&donors.sex=${item}`);
+                            }
+                        }
+                    },
+                },
+            });
+            document.getElementById(`${chartId}-legend`).innerHTML = chart.generateLegend();
+            resolve(chart);
+        }, 'chartjs');
+    });
+}
 
 // Display and handle clicks in the chart of labs.
 export class LabChart extends React.Component {

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -330,6 +330,7 @@ export const donorSexList = [
 export const projectColors = new DataColors(projectList);
 export const biosampleTypeColors = new DataColors(biosampleTypeList);
 export const replicateTypeColors = new DataColors(replicateTypeList);
+export const donorSexColors = new DataColors(donorSexList);
 
 
 // Map view icons to svg icons.

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -319,6 +319,12 @@ export const replicateTypeList = [
     'anisogenic',
 ];
 
+export const donorSexList = [
+    'female',
+    'male',
+    'unknown',
+];
+
 
 // Make `project` and `biosample_type` color mappings for downstream modules to use.
 export const projectColors = new DataColors(projectList);

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -393,23 +393,12 @@ class SummaryBody extends React.Component {
                             <ViewControls results={this.props.context} alternativeNames={['Tabular report', 'Summary matrix']} />
                         </div>
                     </div>
-                    {(this.state.selectedOrganism === 'Homo sapiens') ?
-                        <React.Fragment>
-                            <div className="flex-container">
-                                <SummaryData context={this.props.context} displayCharts={'donuts'} />
-                            </div>
-                            <div className="summary-content">
-                                <SummaryData context={this.props.context} displayCharts={'area'} />
-                            </div>
-                        </React.Fragment>
-                    :
-                        <React.Fragment>
-                            <SummaryHorizontalFacets context={this.props.context} facetList={'all'} />
-                            <div className="summary-content">
-                                <SummaryData context={this.props.context} displayCharts={'all'} />
-                            </div>
-                        </React.Fragment>
-                    }
+                    <React.Fragment>
+                        <SummaryHorizontalFacets context={this.props.context} facetList={'all'} />
+                        <div className="summary-content">
+                            <SummaryData context={this.props.context} displayCharts={'all'} />
+                        </div>
+                    </React.Fragment>
                 </div>
             </div>
         );

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -108,7 +108,7 @@ class SummaryStatusChart extends React.Component {
         // Generate colors to use for each sex value.
         const colors = globals.donorSexColors.colorList(globals.donorSexList);
 
-        createNewBarChart(this.chartId, data, colors, globals.donorSexList, 'Donor sex', this.props.linkUri, (uri) => { this.context.navigate(uri); })
+        createNewBarChart(this.chartId, data, colors, globals.donorSexList, this.props.linkUri, (uri) => { this.context.navigate(uri); })
             .then((chartInstance) => {
                 // Save the created chart instance.
                 this.chart = chartInstance;
@@ -193,7 +193,7 @@ SummaryStatusChart.contextTypes = {
 const SummaryHorizontalFacets = ({ context, facetList }, reactContext) => {
     let horizFacets;
     if (facetList === 'all') {
-        horizFacets = context.facets.filter(f => ['donors.ethnicity.term_name', 'donors.sex', 'donors.life_stage', 'biosample_ontologies.organ_slims', 'biosample_ontologies.term_name', 'award.project', 'award.coordinating_pi.title', 'lab.title'].includes(f.field));
+        horizFacets = context.facets.filter(f => ['donors.organism.scientific_name', 'donors.ethnicity.term_name', 'donors.sex', 'donors.life_stage', 'biosample_ontologies.organ_slims', 'biosample_ontologies.term_name', 'award.project', 'award.coordinating_pi.title', 'lab.title'].includes(f.field));
     } else {
         horizFacets = context.facets.filter(f => [].includes(f.field));
     }
@@ -373,20 +373,6 @@ class SummaryBody extends React.Component {
                     <ClearFilters searchUri={this.props.context.clear_filters} enableDisplay={!!clearButton} />
                 </div>
                 <div className="summary-controls">
-                    <div className="organism-button-instructions">Choose an organism:</div>
-                    <div className="organism-button-container">
-                        {organismTerms.map(term =>
-                            <button
-                                id={term}
-                                onClick={e => this.chooseOrganism(e)}
-                                className={`organism-button ${term.replace(' ', '-')} ${this.state.selectedOrganism === term ? 'active' : ''}`}
-                                key={term}
-                            >
-                                <img src={`/static/img/bodyMap/organisms/${term.replace(' ', '-')}.png`} alt={term} />
-                                <span>{term}</span>
-                            </button>
-                        )}
-                    </div>
                     <div className={`results-controls ${this.state.selectedOrganism.length > 0 ? `${this.state.selectedOrganism.replace(' ', '-')}` : ''}`}>
                         <div className="results-count">There {this.props.context.total > 1 ? 'are' : 'is'} <b className="bold-total">{this.props.context.total}</b> result{this.props.context.total > 1 ? 's' : ''}.</div>
                         <div className="view-controls-container">

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -193,7 +193,7 @@ SummaryStatusChart.contextTypes = {
 const SummaryHorizontalFacets = ({ context, facetList }, reactContext) => {
     let horizFacets;
     if (facetList === 'all') {
-        horizFacets = context.facets.filter(f => ['donors.ethnicity.term_name', 'donors.sex', 'biosample_ontologies.organ_slims', 'biosample_ontologies.term_name', 'award.project', 'award.name', 'lab.title'].includes(f.field));
+        horizFacets = context.facets.filter(f => ['donors.ethnicity.term_name', 'donors.sex', 'donors.life_stage', 'biosample_ontologies.organ_slims', 'biosample_ontologies.term_name', 'award.project', 'award.coordinating_pi.title', 'lab.title'].includes(f.field));
     } else {
         horizFacets = context.facets.filter(f => [].includes(f.field));
     }

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -5,12 +5,11 @@ import url from 'url';
 import * as encoding from '../libs/query_encoding';
 import QueryString from '../libs/query_string';
 import { Panel, PanelBody } from '../libs/ui/panel';
-import { LabChart, CategoryChart, ExperimentDate, createBarChart } from './award';
+import { LabChart, CategoryChart, createBarChart } from './award';
 import * as globals from './globals';
 import { FacetList, ClearFilters } from './search';
 import { getObjectStatuses, sessionToAccessLevel } from './status';
 import { ViewControls } from './view_controls';
-import BodyMap, { systemsField, organField } from './body_map';
 
 /**
  * Generate an array of data from one facet bucket for displaying in a chart, with one array entry
@@ -21,6 +20,17 @@ import BodyMap, { systemsField, organField } from './body_map';
  * @param {array} labels - Experiment status labels.
  * @return {array} - Data extracted from buckets with an order of values corresponding to `labels`.
  */
+
+// Data field for organism
+// We will display different facets depending on the selected organism
+const organismField = 'donors.organism.scientific_name';
+
+// Mapping of shortened organism name and full scientific organism name
+const organismTerms = [
+    'Homo sapiens',
+    'Mus musculus',
+];
+
 function generateStatusData(buckets, labels) {
     // Fill the array to the proper length with zeroes to start with. Actual non-zero data will
     // overwrite the appropriate entries.
@@ -38,17 +48,9 @@ function generateStatusData(buckets, labels) {
     return statusData;
 }
 
-// Data field for organism
-// We will display different facets depending on the selected organism
-const organismField = 'replicates.library.biosample.donor.organism.scientific_name';
-
-// Mapping of shortened organism name and full scientific organism name
-const organismTerms = [
-    'Homo sapiens',
-    'Mus musculus',
-    'Drosophila melanogaster',
-    'Caenorhabditis elegans',
-];
+function gatherEthnicityNames() {
+    return ['Asian', 'European', 'Korean', 'Taiwanese', 'Hispanic or Latin American', 'not reported']
+}
 
 // Column graph of experiment statuses.
 class SummaryStatusChart extends React.Component {
@@ -80,29 +82,28 @@ class SummaryStatusChart extends React.Component {
 
     createChart() {
         const { statusData } = this.props;
-        const accessLevel = sessionToAccessLevel(this.context.session, this.context.session_properties);
-        const experimentStatuses = getObjectStatuses('Dataset', accessLevel);
+        const ethnicityNames = gatherEthnicityNames();
 
         // Initialize data object to pass to createBarChart.
         const data = {
             anisogenicDataset: null,
             isogenicDataset: null,
             unreplicatedDataset: null,
-            labels: experimentStatuses,
+            labels: ethnicityNames,
         };
 
         // Convert statusData to a form createBarChart understands.
-        let facetData = statusData.find(facet => facet.key === 'anisogenic');
-        data.anisogenicDataset = facetData ? generateStatusData(facetData.status.buckets, data.labels) : [];
-        facetData = statusData.find(facet => facet.key === 'isogenic');
-        data.isogenicDataset = facetData ? generateStatusData(facetData.status.buckets, data.labels) : [];
-        facetData = statusData.find(facet => facet.key === 'unreplicated');
-        data.unreplicatedDataset = facetData ? generateStatusData(facetData.status.buckets, data.labels) : [];
+        let facetData = statusData.find(facet => facet.key === 'female');
+        data.anisogenicDataset = facetData ? generateStatusData(facetData.term_name.buckets, data.labels) : [];
+        facetData = statusData.find(facet => facet.key === 'male');
+        data.isogenicDataset = facetData ? generateStatusData(facetData.term_name.buckets, data.labels) : [];
+        facetData = statusData.find(facet => facet.key === 'unknown');
+        data.unreplicatedDataset = facetData ? generateStatusData(facetData.term_name.buckets, data.labels) : [];
 
         // Generate colors to use for each replicate type.
-        const colors = globals.replicateTypeColors.colorList(globals.replicateTypeList);
+        const colors = globals.replicateTypeColors.colorList(globals.donorSexList);
 
-        createBarChart(this.chartId, data, colors, globals.replicateTypeList, 'Replication', this.props.linkUri, (uri) => { this.context.navigate(uri); })
+        createBarChart(this.chartId, data, colors, globals.donorSexList, 'Donor sex', this.props.linkUri, (uri) => { this.context.navigate(uri); })
             .then((chartInstance) => {
                 // Save the created chart instance.
                 this.chart = chartInstance;
@@ -110,18 +111,17 @@ class SummaryStatusChart extends React.Component {
     }
 
     updateChart(chart, statusData) {
-        const replicateTypeColors = globals.replicateTypeColors.colorList(globals.replicateTypeList);
-        const accessLevel = sessionToAccessLevel(this.context.session, this.context.session_properties);
-        const experimentStatuses = getObjectStatuses('Dataset', accessLevel);
+        const replicateTypeColors = globals.replicateTypeColors.colorList(globals.donorSexList);
+        const ethnicityNames = gatherEthnicityNames();
 
         // For each replicate type, extract the data for each status to assign to the existing
         // chart's dataset.
         const datasets = [];
-        globals.replicateTypeList.forEach((replicateType, replicateTypeIndex) => {
+        globals.donorSexList.forEach((replicateType, replicateTypeIndex) => {
             const facetData = statusData.find(facet => facet.key === replicateType);
             if (facetData) {
                 // Get an array of replicate data per status from the facet data.
-                const data = generateStatusData(facetData.status.buckets, experimentStatuses);
+                const data = generateStatusData(facetData.term_name.buckets, ethnicityNames);
 
                 datasets.push({
                     backgroundColor: replicateTypeColors[replicateTypeIndex],
@@ -133,7 +133,7 @@ class SummaryStatusChart extends React.Component {
 
         // Update the chart data, then force a redraw of the chart and legend.
         chart.data.datasets = datasets;
-        chart.data.labels = experimentStatuses;
+        chart.data.labels = ethnicityNames;
         chart.update();
         document.getElementById(`${this.chartId}-legend`).innerHTML = chart.generateLegend();
     }
@@ -181,9 +181,9 @@ SummaryStatusChart.contextTypes = {
 const SummaryHorizontalFacets = ({ context, facetList }, reactContext) => {
     let horizFacets;
     if (facetList === 'all') {
-        horizFacets = context.facets.filter(f => ['biosample_ontology.organ_slims', 'biosample_ontology.cell_slims', 'assay_title', 'date_released', 'date_submitted'].includes(f.field));
+        horizFacets = context.facets.filter(f => ['donors.ethnicity.term_name', 'donors.sex', 'biosample_ontologies.organ_slims', 'biosample_ontologies.term_name', 'award.project', 'award.name', 'lab.title'].includes(f.field));
     } else {
-        horizFacets = context.facets.filter(f => ['assay_title', 'biosample_ontology.term_name', 'date_released', 'date_submitted'].includes(f.field));
+        horizFacets = context.facets.filter(f => [].includes(f.field));
     }
 
     // Calculate the searchBase, which is the current search query string fragment that can have
@@ -263,7 +263,7 @@ class SummaryData extends React.Component {
         // Find the labs and assay facets in the search results.
         const labFacet = context.facets.find(facet => facet.field === 'lab.title');
         let labs = labFacet ? labFacet.terms : null;
-        const assayFacet = context.facets.find(facet => facet.field === 'assay_title');
+        const assayFacet = context.facets.find(facet => facet.field === 'assay');
         let assays = assayFacet ? assayFacet.terms : null;
 
         const filteredOutLabs = context.filters.filter(c => c.field === 'lab.title!');
@@ -297,7 +297,7 @@ class SummaryData extends React.Component {
         if (context.filters && context.filters.length > 0) {
             searchQuery = context.filters.map(filter => `${filter.field}=${encoding.encodedURIComponentOLD(filter.term)}`).join('&');
         }
-        const linkUri = `/matrix/?${searchQuery}`;
+        const linkUri = `/report/?${searchQuery}`;
         const displayCharts = this.props.displayCharts;
 
         return (
@@ -305,13 +305,7 @@ class SummaryData extends React.Component {
                 {(displayCharts === 'all' || displayCharts === 'donuts') ?
                     <div className="summary-content__snapshot">
                         {labs ? <LabChart labs={labs} linkUri={linkUri} ident="experiments" filteredOutLabs={filteredOutLabs} /> : null}
-                        {assays ? <CategoryChart categoryData={assays} categoryFacet="assay_title" title="Assay" linkUri={linkUri} ident="assay" filteredOutAssays={filteredOutAssays} /> : null}
-                        {statusDataCount ? <SummaryStatusChart statusData={statusData} totalStatusData={statusDataCount} linkUri={linkUri} ident="status" /> : null}
-                    </div>
-                : null}
-                {(displayCharts === 'all' || displayCharts === 'area') ?
-                    <div className="summary-content__statistics">
-                        <ExperimentDate experiments={context} panelCss="summary-content__panel" panelHeadingCss="summary-content__panel-heading" />
+                        {assays ? <CategoryChart categoryData={assays} categoryFacet="assay" title="Assay" linkUri={linkUri} ident="assay" filteredOutAssays={filteredOutAssays} /> : null}
                     </div>
                 : null}
             </div>
@@ -383,7 +377,7 @@ class SummaryBody extends React.Component {
                     <div className={`results-controls ${this.state.selectedOrganism.length > 0 ? `${this.state.selectedOrganism.replace(' ', '-')}` : ''}`}>
                         <div className="results-count">There {this.props.context.total > 1 ? 'are' : 'is'} <b className="bold-total">{this.props.context.total}</b> result{this.props.context.total > 1 ? 's' : ''}.</div>
                         <div className="view-controls-container">
-                            <ViewControls results={this.props.context} alternativeNames={['Search list', 'Tabular report', 'Summary matrix']} />
+                            <ViewControls results={this.props.context} alternativeNames={['Tabular report', 'Summary matrix']} />
                         </div>
                     </div>
                     {(this.state.selectedOrganism === 'Homo sapiens') ?

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -11,6 +11,7 @@ import { requestSearch } from './objectutils';
 import { FacetList, ClearFilters } from './search';
 import { getObjectStatuses, sessionToAccessLevel } from './status';
 import { ViewControls } from './view_controls';
+import { systemsField, organField } from './body_map';
 
 /**
  * Generate an array of data from one facet bucket for displaying in a chart, with one array entry
@@ -147,7 +148,6 @@ class SummaryStatusChart extends React.Component {
         chart.data.datasets = datasets;
         chart.data.labels = ethnicityNames;
         chart.update();
-        document.getElementById(`${this.chartId}-legend`).innerHTML = chart.generateLegend();
     }
 
     render() {
@@ -193,7 +193,7 @@ SummaryStatusChart.contextTypes = {
 const SummaryHorizontalFacets = ({ context, facetList }, reactContext) => {
     let horizFacets;
     if (facetList === 'all') {
-        horizFacets = context.facets.filter(f => ['donors.organism.scientific_name', 'donors.ethnicity.term_name', 'donors.sex', 'donors.life_stage', 'biosample_ontologies.organ_slims', 'biosample_ontologies.term_name', 'award.project', 'award.coordinating_pi.title', 'lab.title'].includes(f.field));
+        horizFacets = context.facets.filter(f => ['donors.ethnicity.term_name', 'donors.sex', 'donors.life_stage', 'biosample_ontologies.organ_slims', 'biosample_ontologies.term_name', 'award.project', 'award.coordinating_pi.title', 'lab.title'].includes(f.field));
     } else {
         horizFacets = context.facets.filter(f => [].includes(f.field));
     }
@@ -373,6 +373,20 @@ class SummaryBody extends React.Component {
                     <ClearFilters searchUri={this.props.context.clear_filters} enableDisplay={!!clearButton} />
                 </div>
                 <div className="summary-controls">
+                    <div className="organism-button-instructions">Choose an organism:</div>
+                    <div className="organism-button-container">
+                        {organismTerms.map(term =>
+                            <button
+                                id={term}
+                                onClick={e => this.chooseOrganism(e)}
+                                className={`organism-button ${term.replace(' ', '-')} ${this.state.selectedOrganism === term ? 'active' : ''}`}
+                                key={term}
+                            >
+                                <img src={`/static/img/bodyMap/organisms/${term.replace(' ', '-')}.png`} alt={term} />
+                                <span>{term}</span>
+                            </button>
+                        )}
+                    </div>
                     <div className={`results-controls ${this.state.selectedOrganism.length > 0 ? `${this.state.selectedOrganism.replace(' ', '-')}` : ''}`}>
                         <div className="results-count">There {this.props.context.total > 1 ? 'are' : 'is'} <b className="bold-total">{this.props.context.total}</b> result{this.props.context.total > 1 ? 's' : ''}.</div>
                         <div className="view-controls-container">
@@ -382,7 +396,6 @@ class SummaryBody extends React.Component {
                     {(this.state.selectedOrganism === 'Homo sapiens') ?
                         <React.Fragment>
                             <div className="flex-container">
-                                <BodyMap context={this.props.context} />
                                 <SummaryData context={this.props.context} displayCharts={'donuts'} />
                             </div>
                             <div className="summary-content">

--- a/src/encoded/tests/data/inserts/award.json
+++ b/src/encoded/tests/data/inserts/award.json
@@ -6,6 +6,7 @@
         "principal_investigators": [
             "agreka@bwh.harvard.ude"
         ],
+        "coordinating_pi": "agreka@bwh.harvard.ude",
         "project": "HCA Seed Networks",
         "status": "current",
         "title": "A Comprehensive Single Cell Atlas of the Human Kidney",
@@ -25,6 +26,7 @@
         "principal_investigators": [
             "jimmie.ye@ucsf.ude"
         ],
+        "coordinating_pi": "jimmie.ye@ucsf.ude",
         "project": "HCA Seed Networks",
         "status": "current",
         "title": "Human Immune Variation Across Genetic Backgrounds, Gender and Time",
@@ -43,6 +45,7 @@
             "quisque.consequat@venenatis.magna",
             "pas2182@columbia.ude"
         ],
+        "coordinating_pi": "pas2182@columbia.ude",
         "project": "HCA Seed Networks",
         "status": "disabled",
         "title": "A Reference Cell Atlas of Human Liver Diversity Over a Lifespan",
@@ -60,6 +63,7 @@
         "principal_investigators": [
             "netus.lorem@risus.lobortis"
         ],
+        "coordinating_pi": "netus.lorem@risus.lobortis",
         "project": "HCA Seed Networks",
         "status": "deleted",
         "title": "Developing Robust Methods to Process Solid Tissues for Single-Cell RNA-sequencing",

--- a/src/encoded/types/dataset.py
+++ b/src/encoded/types/dataset.py
@@ -42,6 +42,7 @@ class Dataset(Item):
         'libraries.lab',
         'libraries.biosample_ontologies',
         'award',
+        'award.coordinating_pi',
         'references',
         'corresponding_contributors',
         'contributors'

--- a/src/encoded/types/library.py
+++ b/src/encoded/types/library.py
@@ -86,37 +86,11 @@ class Library(Item, CalculatedAward, CalculatedBiosampleOntologies):
         return sorted(all_donors)
 
 
-    matrix = {
-        'y': {
-            'group_by': ['donors.ethnicity', 'biosample_ontologies.term_name'],
-            'label': 'Biosample',
-        },
-        'x': {
-            'group_by': ['assay', 'protocol.title'],
-            'label': 'Protocol',
-        },
-    }
-
-
-    summary = {
-        'y': {
-            'group_by': ['donors.ethnicity', 'biosample_ontologies.term_name'],
-            'label': 'Biosample',
-        },
-        'x': {
-            'group_by': ['assay', 'protocol.title'],
-            'label': 'Protocol',
-        },
-    }
-
-
     summary_matrix = {
-        'y': {
-            'group_by': ['donors.ethnicity', 'biosample_ontologies.term_name'],
-            'label': 'Biosample',
-        },
         'x': {
-            'group_by': ['assay', 'protocol.title'],
-            'label': 'Protocol',
+            'group_by': 'donors.ethnicity.term_name'
         },
+        'y': {
+            'group_by': ['donors.sex']
+        }
     }

--- a/src/encoded/types/library.py
+++ b/src/encoded/types/library.py
@@ -26,6 +26,7 @@ class Library(Item, CalculatedAward, CalculatedBiosampleOntologies):
     rev = {}
     embedded = [
         'award',
+        'award.coordinating_pi',
         'lab',
         'protocol',
         'donors',

--- a/src/encoded/types/library.py
+++ b/src/encoded/types/library.py
@@ -84,3 +84,39 @@ class Library(Item, CalculatedAward, CalculatedBiosampleOntologies):
             bs_obj = request.embed(bs, '@@object')
             all_donors.update(bs_obj.get('donors'))
         return sorted(all_donors)
+
+
+    matrix = {
+        'y': {
+            'group_by': ['donors.ethnicity', 'biosample_ontologies.term_name'],
+            'label': 'Biosample',
+        },
+        'x': {
+            'group_by': ['assay', 'protocol.title'],
+            'label': 'Protocol',
+        },
+    }
+
+
+    summary = {
+        'y': {
+            'group_by': ['donors.ethnicity', 'biosample_ontologies.term_name'],
+            'label': 'Biosample',
+        },
+        'x': {
+            'group_by': ['assay', 'protocol.title'],
+            'label': 'Protocol',
+        },
+    }
+
+
+    summary_matrix = {
+        'y': {
+            'group_by': ['donors.ethnicity', 'biosample_ontologies.term_name'],
+            'label': 'Biosample',
+        },
+        'x': {
+            'group_by': ['assay', 'protocol.title'],
+            'label': 'Protocol',
+        },
+    }


### PR DESCRIPTION
Revive previously-deleted code to form a /summary/ view, specifically for Library objects
Updated the summary page to add facets and redesign charts
Added coordinating_pi to Award for ease of selecting a specific Seed Network award