### PR TITLE
LAT-136 biosample calcprops

### DIFF
--- a/src/encoded/schemas/cell_culture.json
+++ b/src/encoded/schemas/cell_culture.json
@@ -132,6 +132,9 @@
         "description": {
             "title": "Description"
         },
+        "summary": {
+            "title": "Summary"
+        },
         "donors.organism.scientific_name": {
             "title": "Organism"
         },

--- a/src/encoded/schemas/dataset.json
+++ b/src/encoded/schemas/dataset.json
@@ -123,6 +123,12 @@
         "libraries.protocol.title": {
             "title": "Library protocol"
         },
+        "libraries.protocol.title": {
+            "title": "Library protocol"
+        },
+        "libraries.biosample_classification": {
+            "title": "Biosample classification"
+        },
         "award.project": {
             "title": "Project"
         },
@@ -161,14 +167,17 @@
         "references.citation": {
             "title": "References"
         },
-        "status": {
-            "title": "Status"
-        },
         "libraries.protocol.title": {
             "title": "Library protocol"
         },
         "libraries.assay": {
             "title": "Assay type"
+        },
+        "libraries.biosample_classification": {
+            "title": "Biosample classification"
+        },
+        "status": {
+            "title": "Status"
         }
     },
     "changelog": "/profiles/changelogs/dataset.md"

--- a/src/encoded/schemas/human_donor.json
+++ b/src/encoded/schemas/human_donor.json
@@ -50,7 +50,8 @@
             "title": "Ethnicity",
             "description": "Ethnic group to which the donor belongs, usually self-reported by the donor.",
             "type": "string",
-            "linkTo": "OntologyTerm"
+            "linkTo": "OntologyTerm",
+            "default": "9ccb9d0b-1747-4ad1-969a-769286937021"
         },
         "parents": {
             "title": "Parents",

--- a/src/encoded/schemas/library.json
+++ b/src/encoded/schemas/library.json
@@ -266,6 +266,9 @@
         "donors.ethnicity.term_name": {
             "title": "Donor ethnicity"
         },
+        "biosample_summary": {
+            "title": "Biosample summary"
+        },
         "biosample_classification": {
             "title": "Biosample classification"
         },

--- a/src/encoded/schemas/library.json
+++ b/src/encoded/schemas/library.json
@@ -200,6 +200,9 @@
         "donors.ethnicity.term_name": {
             "title": "Donor ethnicity"
         },
+        "biosample_classification": {
+            "title": "Biosample classification"
+        },
         "biosample_ontologies.system_slims": {
             "title": "Biosample system"
         },
@@ -262,6 +265,9 @@
         },
         "donors.ethnicity.term_name": {
             "title": "Donor ethnicity"
+        },
+        "biosample_classification": {
+            "title": "Biosample classification"
         },
         "biosample_ontologies.term_name": {
             "title": "Biosample term name"

--- a/src/encoded/schemas/ontology_term.json
+++ b/src/encoded/schemas/ontology_term.json
@@ -35,7 +35,7 @@
             "permission": "import_items",
             "comment": "For detailed description of ontologies used by Lattice visit https://www.lattice-data.org/data-organization/. In cases where a new ontology term is needed, NTR (new term request) identifier would be created by Lattice.",
             "type": "string",
-            "pattern": "^(UBERON|EFO|CL|MONDO|HANCESTRO|NTR):[0-9]{2,8}$"
+            "pattern": "(^(UBERON|EFO|CL|MONDO|HANCESTRO|NTR):[0-9]{2,8}$)|^(NCIT:C17998)$"
         },
         "term_name": {
             "title": "Term name",

--- a/src/encoded/schemas/organoid.json
+++ b/src/encoded/schemas/organoid.json
@@ -109,6 +109,9 @@
         "description": {
             "title": "Description"
         },
+        "summary": {
+            "title": "Summary"
+        },
         "donors.organism.scientific_name": {
             "title": "Organism"
         },

--- a/src/encoded/schemas/suspension.json
+++ b/src/encoded/schemas/suspension.json
@@ -296,6 +296,12 @@
         "donors.sex": {
             "title": "Donor sex"
         },
+        "donors.diseases.term_name": {
+            "title": "Donor diseases"
+        },
+        "donors.ethnicity.term_name": {
+            "title": "Donor ethnicity"
+        },
         "suspension_type": {
             "title": "Suspension type"
         },
@@ -336,6 +342,12 @@
         },
         "donors.sex": {
             "title": "Donor sex"
+        },
+        "donors.diseases.term_name": {
+            "title": "Donor diseases"
+        },
+        "donors.ethnicity.term_name": {
+            "title": "Donor ethnicity"
         },
         "biosample_classification": {
             "title": "Biosample classification"

--- a/src/encoded/schemas/suspension.json
+++ b/src/encoded/schemas/suspension.json
@@ -334,6 +334,9 @@
         "description": {
             "title": "Description"
         },
+        "biosample_summary": {
+            "title": "Biosample summary"
+        },
         "donors.organism.scientific_name": {
             "title": "Organism"
         },

--- a/src/encoded/schemas/suspension.json
+++ b/src/encoded/schemas/suspension.json
@@ -299,6 +299,9 @@
         "suspension_type": {
             "title": "Suspension type"
         },
+        "biosample_classification": {
+            "title": "Biosample classification"
+        },
         "biosample_ontologies.system_slims": {
             "title": "Biosample system"
         },
@@ -333,6 +336,9 @@
         },
         "donors.sex": {
             "title": "Donor sex"
+        },
+        "biosample_classification": {
+            "title": "Biosample classification"
         },
         "derived_from": {
             "title": "Derived from"

--- a/src/encoded/schemas/tissue.json
+++ b/src/encoded/schemas/tissue.json
@@ -226,6 +226,12 @@
         "description": {
             "title": "Description"
         },
+        "summary": {
+            "title": "Summary"
+        },
+        "treatment_summary": {
+            "title": "Treatment summary"
+        },
         "donors.organism.scientific_name": {
             "title": "Organism"
         },
@@ -234,9 +240,6 @@
         },
         "donors.sex": {
             "title": "Donor sex"
-        },
-        "treatment_summary": {
-            "title": "Treatment summary"
         },
         "biosample_ontology.system_slims": {
             "title": "System"

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -60,7 +60,7 @@ const portal = {
                 { id: 'sep-mm-1' },
                 { id: 'publications', title: 'Publications', url: '/report/?type=Publication' },
                 { id: 'sep-mm-0' },
-                { id: 'lib-summ', title: 'Data summary', url: '/summary/?type=Library&award.project=HCA+Seed+Networks' },
+                { id: 'lib-summ', title: 'Data summary', url: '/summary/?type=Library&award.project=HCA+Seed+Networks&donors.organism.scientific_name=Homo+sapiens' },
             ],
         },
         {

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -378,17 +378,9 @@ export function createNewBarChart(chartId, data, colors, replicateLabels, baseSe
                             //      that is passed to the createDonutChart or createBarChart functions because cannot directly
                             //      make changes to the param baseSearchUri in updateChart().
                             if (chart.options.onClick.baseSearchUri) {
-                                if (encoding.encodedURIComponentOLD(term) === 'unknown') {
-                                    navigate(`${chart.options.onClick.baseSearchUri}&donors.ethnicity!=*&donors.sex=${item}`);
-                                } else {
-                                    navigate(`${chart.options.onClick.baseSearchUri}&donors.ethnicity.term_name=${encoding.encodedURIComponentOLD(term)}&donors.sex=${item}`);
-                                }
+                                navigate(`${chart.options.onClick.baseSearchUri}&donors.ethnicity.term_name=${encoding.encodedURIComponentOLD(term)}&donors.sex=${item}`);
                             } else {
-                                if (encoding.encodedURIComponentOLD(term) === 'unknown') {
-                                    navigate(`${baseSearchUri}&donors.ethnicity!=*&donors.sex=${item}`);
-                                } else {
-                                    navigate(`${baseSearchUri}&donors.ethnicity.term_name=${encoding.encodedURIComponentOLD(term)}&donors.sex=${item}`);
-                                }
+                                navigate(`${baseSearchUri}&donors.ethnicity.term_name=${encoding.encodedURIComponentOLD(term)}&donors.sex=${item}`);
                             }
                         }
                     },

--- a/src/encoded/static/components/award.js
+++ b/src/encoded/static/components/award.js
@@ -314,9 +314,6 @@ export function createNewBarChart(chartId, data, colors, replicateLabels, baseSe
             if (data.femaleDataset.some(x => x > 0)) {
                 datasets.push({ label: 'female', data: data.femaleDataset, backgroundColor: colors[2] });
             }
-            for (let i = 0; i < datasets.length; i += 1) {
-                datasets[i].backgroundColor = colors[i];
-            }
 
             // Create the chart.
             const canvas = document.getElementById(`${chartId}-chart`);
@@ -381,9 +378,17 @@ export function createNewBarChart(chartId, data, colors, replicateLabels, baseSe
                             //      that is passed to the createDonutChart or createBarChart functions because cannot directly
                             //      make changes to the param baseSearchUri in updateChart().
                             if (chart.options.onClick.baseSearchUri) {
-                                navigate(`${chart.options.onClick.baseSearchUri}&donors.ethnicity.term_name=${encoding.encodedURIComponentOLD(term)}&donors.sex=${item}`);
+                                if (encoding.encodedURIComponentOLD(term) === 'unknown') {
+                                    navigate(`${chart.options.onClick.baseSearchUri}&donors.ethnicity!=*&donors.sex=${item}`);
+                                } else {
+                                    navigate(`${chart.options.onClick.baseSearchUri}&donors.ethnicity.term_name=${encoding.encodedURIComponentOLD(term)}&donors.sex=${item}`);
+                                }
                             } else {
-                                navigate(`${baseSearchUri}&donors.ethnicity.term_name=${encoding.encodedURIComponentOLD(term)}&donors.sex=${item}`);
+                                if (encoding.encodedURIComponentOLD(term) === 'unknown') {
+                                    navigate(`${baseSearchUri}&donors.ethnicity!=*&donors.sex=${item}`);
+                                } else {
+                                    navigate(`${baseSearchUri}&donors.ethnicity.term_name=${encoding.encodedURIComponentOLD(term)}&donors.sex=${item}`);
+                                }
                             }
                         }
                     },

--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -466,8 +466,19 @@ const DatasetComponent = ({ context, auditIndicators, auditDetail }, reactContex
         return null;
     }
 
+    function libraryListList(values, field) {
+        if (values && values.length > 0) {
+            const mySet = new Set();
+            values.forEach(x => x[field].forEach(y => mySet.add(y)));
+            const myList = Array.from(mySet).join(", ");
+            return myList;
+        }
+        return null;
+    }
+
     const library_types  = libraryList(context.libraries, 'assay');
-    const library_titles = libraryList(context.libraries, 'protocol_title');
+    const library_titles = libraryProtocolList(context.libraries, 'title');
+    const biosample_classification = libraryListList(context.libraries, 'biosample_classification');
 
     return (
         <div className={itemClass}>
@@ -496,6 +507,13 @@ const DatasetComponent = ({ context, auditIndicators, auditDetail }, reactContex
                                 <div data-test="description">
                                     <dt>Description</dt>
                                     <dd>{context.description}</dd>
+                                </div>
+                            : null}
+
+                            {biosample_classification ?
+                                <div data-test="biosample_classification">
+                                    <dt>Biosample classification</dt>
+                                    <dd>{biosample_classification}</dd>
                                 </div>
                             : null}
 

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -40,7 +40,7 @@ const Donor = (props) => {
                             <dd>{biosample ? <a href={context['@id']}>{context.accession}</a> : context.accession}</dd>
                         </div>
 
-                        {context.aliases.length > 0 ?
+                        {context.aliases > 0 ?
                             <div data-test="aliases">
                                 <dt>Aliases</dt>
                                 <dd>{context.aliases.join(', ')}</dd>

--- a/src/encoded/static/components/globals.js
+++ b/src/encoded/static/components/globals.js
@@ -320,9 +320,9 @@ export const replicateTypeList = [
 ];
 
 export const donorSexList = [
-    'female',
-    'male',
     'unknown',
+    'male',
+    'female',
 ];
 
 

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -53,8 +53,6 @@ class SummaryStatusChart extends React.Component {
         if (this.props.totalStatusData) {
             this.createChart();
         }
-
-        const query_url = this.props.linkUri.replace('/report/?', '')
     }
 
     componentDidUpdate() {
@@ -62,7 +60,7 @@ class SummaryStatusChart extends React.Component {
             if (this.chart) {
                 this.updateChart(this.chart, this.props.statusData);
             } else {
-                const query_url = this.props.linkUri.replace('/report/?', '')
+                this.createChart();
             }
         } else if (this.chart) {
             this.chart.destroy();

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -47,9 +47,6 @@ class SummaryStatusChart extends React.Component {
         this.chart = null;
         this.createChart = this.createChart.bind(this);
         this.updateChart = this.updateChart.bind(this);
-        this.state = {
-            unknownCount: 0
-        }
     }
 
     componentDidMount() {
@@ -58,7 +55,6 @@ class SummaryStatusChart extends React.Component {
         }
 
         const query_url = this.props.linkUri.replace('/report/?', '')
-        this.getNoEth(query_url);
     }
 
     componentDidUpdate() {
@@ -67,34 +63,11 @@ class SummaryStatusChart extends React.Component {
                 this.updateChart(this.chart, this.props.statusData);
             } else {
                 const query_url = this.props.linkUri.replace('/report/?', '')
-                this.getNoEth(query_url);
-                this.createChart();
             }
         } else if (this.chart) {
             this.chart.destroy();
             this.chart = null;
         }
-    }
-
-    getNoEth(searchBase) {
-        const statusData = this.props.statusData
-        requestSearch(searchBase + '&donors.ethnicity!=*&limit=all').then((results) => {
-            if (Object.keys(results).length > 0 && results['@graph'].length > 0) {
-                this.setState({
-                    unknownCount: results.total
-                })
-                const sexFacet = results['facets'].find(facet => facet.field === 'donors.sex');
-                globals.donorSexList.forEach(x => {
-                    if (sexFacet['terms'].find(facet => facet.key === x)) {
-                        const unknownData = sexFacet['terms'].find(facet => facet.key === x);
-                        const unknownTotal = unknownData.doc_count;
-                        const myData = statusData.find(facet => facet.key === x);
-                        myData.doc_count += unknownTotal;
-                        myData['donors.ethnicity.term_name'].buckets.push({key: 'unknown', doc_count: unknownTotal});
-                    }
-                })
-            }
-        })
     }
 
     createChart() {
@@ -107,7 +80,6 @@ class SummaryStatusChart extends React.Component {
             }
         });
         const ethnicityNames = Array.from(ethnicityFacet, x => x['key']);
-        this.state.unknownCount > 0 ? ethnicityNames.push('unknown') : null;
 
         // Initialize data object to pass to createBarChart.
         const data = {
@@ -145,7 +117,6 @@ class SummaryStatusChart extends React.Component {
             }
         });
         const ethnicityNames = Array.from(ethnicityFacet, x => x['key']);
-        this.state.unknownCount > 0 ? ethnicityNames.push('unknown') : null;
 
         // For each sex value, extract the data for each status to assign to the existing
         // chart's dataset.

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -327,7 +327,7 @@ class SummaryBody extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            CellCount: 0
+            cellCount: 0
         }
         const searchQuery = url.parse(this.props.context['@id']).search;
         const terms = queryString.parse(searchQuery);
@@ -347,7 +347,7 @@ class SummaryBody extends React.Component {
                     var cell_count = 0
                     results2['@graph'].forEach(y => cell_count += y['observation_count']);
                     this.setState({
-                        CellCount: cell_count
+                        cellCount: cell_count
                     })
                 })
             }
@@ -362,7 +362,7 @@ class SummaryBody extends React.Component {
         context.facets.forEach(x => {
             if (vertFacetNames.includes(x.field)) vertFacets.push(x);
             })
-        const cell_count = this.state.CellCount.toLocaleString();
+        const cell_count = this.state.cellCount.toLocaleString();
         return (
             <div className="search-results">
                 <div className="search-results__facets">

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -66,6 +66,8 @@ class SummaryStatusChart extends React.Component {
             if (this.chart) {
                 this.updateChart(this.chart, this.props.statusData);
             } else {
+                const query_url = this.props.linkUri.replace('/report/?', '')
+                this.getNoEth(query_url);
                 this.createChart();
             }
         } else if (this.chart) {
@@ -82,12 +84,14 @@ class SummaryStatusChart extends React.Component {
                     unknownCount: results.total
                 })
                 const sexFacet = results['facets'].find(facet => facet.field === 'donors.sex');
-                globals.donorSexList.forEach(x => {const unknownData = sexFacet['terms'].find(facet => facet.key === x) ?
-                    sexFacet['terms'].find(facet => facet.key === x) : null;
-                    const unknownTotal = unknownData.doc_count;
-                    const myData = statusData.find(facet => facet.key === x);
-                    myData.doc_count += unknownTotal;
-                    myData['donors.ethnicity.term_name'].buckets.push({key: 'unknown', doc_count: unknownTotal});
+                globals.donorSexList.forEach(x => {
+                    if (sexFacet['terms'].find(facet => facet.key === x)) {
+                        const unknownData = sexFacet['terms'].find(facet => facet.key === x);
+                        const unknownTotal = unknownData.doc_count;
+                        const myData = statusData.find(facet => facet.key === x);
+                        myData.doc_count += unknownTotal;
+                        myData['donors.ethnicity.term_name'].buckets.push({key: 'unknown', doc_count: unknownTotal});
+                    }
                 })
             }
         })

--- a/src/encoded/static/components/summary.js
+++ b/src/encoded/static/components/summary.js
@@ -372,7 +372,7 @@ class SummaryBody extends React.Component {
         nonPersistentQuery.deleteKeyValue('?type');
         const clearButton = nonPersistentQuery.queryCount() > 0 && query.queryCount('?type') > 0;
         const context = this.props.context;
-        const vertFacetNames = ['assay', 'protocol.title', 'biosample_ontologies.system_slims', 'biosample_ontologies.organ_slims', 'biosample_ontologies.term_name', 'award.project', 'award.coordinating_pi.title'];
+        const vertFacetNames = ['assay', 'protocol.title', 'biosample_classification', 'biosample_ontologies.system_slims', 'biosample_ontologies.organ_slims', 'biosample_ontologies.term_name', 'award.project', 'award.coordinating_pi.title'];
         const vertFacets = []
         context.facets.forEach(x => {
             if (vertFacetNames.includes(x.field)) vertFacets.push(x);

--- a/src/encoded/tests/data/inserts/human_prenatal_donor.json
+++ b/src/encoded/tests/data/inserts/human_prenatal_donor.json
@@ -112,7 +112,6 @@
             "MONDO_0005147"
         ],
     	"sex": "unknown",
-    	"ethnicity": "HANCESTRO_0008",
     	"crown_rump_length": 54,
     	"crown_rump_length_units": "mm",
     	"foot_length": 9,

--- a/src/encoded/tests/data/inserts/ontology_term.json
+++ b/src/encoded/tests/data/inserts/ontology_term.json
@@ -1,5 +1,11 @@
 [
     {
+        "uuid": "9ccb9d0b-1747-4ad1-969a-769286937021",
+        "term_name": "unknown",
+        "term_id": "NCIT:C17998",
+        "status": "released"
+    },
+    {
         "uuid": "9a69c3a9-f88c-49db-8b6b-fc69ec3623a5",
         "term_name": "epithelium of left lung",
         "term_id": "UBERON:0003365",

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -68,7 +68,7 @@ ALLOW_CURRENT = [
 
 DELETED = [
     (Deny, Everyone, 'visible_for_edit')
-] + ONLY_ADMIN_VIEW
+]
 
 
 # Collection acls

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -43,6 +43,28 @@ class Biosample(Item, CalculatedDonors):
     ]
 
     @calculated_property(schema={
+        "title": "Summary",
+        "description": "A summary of the treatments applied to the Biosample.",
+        "comment": "Do not submit. This is a calculated property",
+        "type": "string",
+        "notSubmittable": True,
+    })
+    def summary(self, request, biosample_ontology, derived_from):
+        summ = ''
+        my_type = self.item_type.replace('_',' ')
+        if my_type == 'organoid':
+            dfrom = set()
+            for df in derived_from:
+                df_obj = request.embed(df, '@@object?skip_calculated=true')
+                df_bo = df_obj.get('biosample_ontology')
+                df_bo_obj = request.embed(df_bo, '@@object?skip_calculated=true')
+                dfrom.add(df_bo_obj.get('term_name'))
+            summ += ','.join(dfrom) + '-derived '
+        bo_obj = request.embed(biosample_ontology, '@@object?skip_calculated=true')
+        summ += bo_obj.get('term_name') + ' ' + my_type
+        return summ
+
+    @calculated_property(schema={
         "title": "Treatment summary",
         "description": "A summary of the treatments applied to the Biosample.",
         "comment": "Do not submit. This is a calculated property",

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -55,10 +55,10 @@ class Biosample(Item, CalculatedDonors):
         if my_type == 'organoid':
             dfrom = set()
             for df in derived_from:
-                df_obj = request.embed(df, '@@object?skip_calculated=true')
-                df_bo = df_obj.get('biosample_ontology')
-                df_bo_obj = request.embed(df_bo, '@@object?skip_calculated=true')
-                dfrom.add(df_bo_obj.get('term_name'))
+                obj = request.embed(df, '@@object?skip_calculated=true')
+                ontology = obj.get('biosample_ontology')
+                ontology_obj = request.embed(ontology, '@@object?skip_calculated=true')
+                dfrom.add(ontology_obj.get('term_name'))
             summ += ','.join(dfrom) + '-derived '
         bo_obj = request.embed(biosample_ontology, '@@object?skip_calculated=true')
         summ += bo_obj.get('term_name') + ' ' + my_type

--- a/src/encoded/types/library.py
+++ b/src/encoded/types/library.py
@@ -9,6 +9,7 @@ from .base import (
 from .shared_calculated_properties import (
     CalculatedAward,
     CalculatedBiosampleOntologies,
+    CalculatedBiosampleClassification,
 )
 
 
@@ -19,7 +20,7 @@ from .shared_calculated_properties import (
         'title': 'Libraries',
         'description': 'Libraries used in the ENCODE project',
     })
-class Library(Item, CalculatedAward, CalculatedBiosampleOntologies):
+class Library(Item, CalculatedAward, CalculatedBiosampleOntologies, CalculatedBiosampleClassification):
     item_type = 'library'
     schema = load_schema('encoded:schemas/library.json')
     name_key = 'accession'

--- a/src/encoded/types/library.py
+++ b/src/encoded/types/library.py
@@ -10,6 +10,7 @@ from .shared_calculated_properties import (
     CalculatedAward,
     CalculatedBiosampleOntologies,
     CalculatedBiosampleClassification,
+    CalculatedBiosampleSummary,
 )
 
 
@@ -20,7 +21,11 @@ from .shared_calculated_properties import (
         'title': 'Libraries',
         'description': 'Libraries used in the ENCODE project',
     })
-class Library(Item, CalculatedAward, CalculatedBiosampleOntologies, CalculatedBiosampleClassification):
+class Library(Item,
+            CalculatedAward,
+            CalculatedBiosampleOntologies,
+            CalculatedBiosampleClassification,
+            CalculatedBiosampleSummary):
     item_type = 'library'
     schema = load_schema('encoded:schemas/library.json')
     name_key = 'accession'

--- a/src/encoded/types/shared_calculated_properties.py
+++ b/src/encoded/types/shared_calculated_properties.py
@@ -56,3 +56,28 @@ class CalculatedBiosampleOntologies:
             elif bs_obj.get('biosample_ontology'):
                 onts.add(bs_obj.get('biosample_ontology'))
         return sorted(onts)
+
+
+class CalculatedBiosampleClassification:
+    @calculated_property(condition='derived_from', define=True, schema={
+        "title": "Biosample classification",
+        "description": "A property to summarize if the object derived from a tissue, organoid, or cell culture.",
+        "comment": "Do not submit. This is a calculated property",
+        "type": "array",
+        "items": {
+            "type": "string"
+        },
+    })
+    def biosample_classification(self, request, derived_from):
+        t = set()
+        for bs in derived_from:
+            bs_obj = request.embed(bs, '@@object')
+            if bs_obj.get('biosample_classification'):
+                t.update(bs_obj.get('biosample_classification'))
+            else:
+                bs_type = bs_obj['@type'][0].lower()
+                if bs_type == 'cellculture':
+                    t.add('cell culture')
+                else:
+                    t.add(bs_type)
+        return sorted(t)

--- a/src/encoded/types/shared_calculated_properties.py
+++ b/src/encoded/types/shared_calculated_properties.py
@@ -81,3 +81,24 @@ class CalculatedBiosampleClassification:
                 else:
                     t.add(bs_type)
         return sorted(t)
+
+
+class CalculatedBiosampleSummary:
+    @calculated_property(condition='derived_from', define=True, schema={
+        "title": "Biosample summary",
+        "description": "A property to summarize the biosample that this object derived from.",
+        "comment": "Do not submit. This is a calculated property",
+        "type": "array",
+        "items": {
+            "type": "string"
+        },
+    })
+    def biosample_summary(self, request, derived_from):
+        summs = set()
+        for bs in derived_from:
+            bs_obj = request.embed(bs, '@@object')
+            if bs_obj.get('biosample_summary'):
+                summs.update(bs_obj.get('biosample_summary'))
+            elif bs_obj.get('summary'):
+                summs.add(bs_obj.get('summary'))
+        return sorted(summs)

--- a/src/encoded/types/suspension.py
+++ b/src/encoded/types/suspension.py
@@ -10,6 +10,7 @@ from .shared_calculated_properties import (
     CalculatedDonors,
     CalculatedBiosampleOntologies,
     CalculatedBiosampleClassification,
+    CalculatedBiosampleSummary,
 )
 
 
@@ -20,7 +21,11 @@ from .shared_calculated_properties import (
         'title': 'Suspensions',
         'description': 'Listing of Suspensions',
     })
-class Suspension(Item, CalculatedDonors, CalculatedBiosampleOntologies, CalculatedBiosampleClassification):
+class Suspension(Item, 
+                CalculatedDonors,
+                CalculatedBiosampleOntologies,
+                CalculatedBiosampleClassification,
+                CalculatedBiosampleSummary):
     item_type = 'suspension'
     schema = load_schema('encoded:schemas/suspension.json')
     name_key = 'accession'

--- a/src/encoded/types/suspension.py
+++ b/src/encoded/types/suspension.py
@@ -9,6 +9,7 @@ from .base import (
 from .shared_calculated_properties import (
     CalculatedDonors,
     CalculatedBiosampleOntologies,
+    CalculatedBiosampleClassification,
 )
 
 
@@ -19,7 +20,7 @@ from .shared_calculated_properties import (
         'title': 'Suspensions',
         'description': 'Listing of Suspensions',
     })
-class Suspension(Item, CalculatedDonors, CalculatedBiosampleOntologies):
+class Suspension(Item, CalculatedDonors, CalculatedBiosampleOntologies, CalculatedBiosampleClassification):
     item_type = 'suspension'
     schema = load_schema('encoded:schemas/suspension.json')
     name_key = 'accession'


### PR DESCRIPTION
Suspension & Library - added biosample_classification that is a list of tissue, organoid, cell_culture based on the derived_from of the Suspension
added a cell count to the summary view
set up the allowance of OntologyTerm object for NCIT:C17998/unknown as a default for ethnicity when not submitted as a HANCESTRO term
added a summary calc prop to Biosample objects & biosample_summary calc prop to Suspension & Library objects
removed view privileges of deleted objects for Users in the group:read-only-admin (WRN-110 to get access set up for CZIers)