### PR TITLE
LAT-162 demultiplexing link

### DIFF
--- a/src/encoded/schemas/sequencing_run.json
+++ b/src/encoded/schemas/sequencing_run.json
@@ -39,6 +39,15 @@
                 "linkTo": "Library"
             }
         },
+        "demultiplexed_link": {
+            "title": "Demultiplexed link",
+            "description": "The pre-pooled sample that the sequencing is assigned to, if from a library of pooled samples, subsequently demultiplexed.",
+            "type": "string",
+            "linkTo": [
+                "Biosample",
+                "Suspension"
+            ]
+        },
         "platform": {
             "title": "Platform",
             "description": "The device used to sequence data.",

--- a/src/encoded/tests/data/inserts/dataset.json
+++ b/src/encoded/tests/data/inserts/dataset.json
@@ -1,6 +1,19 @@
 [
     {
         "aliases": [
+            "lattice:multiplexed_dataset"
+        ],
+        "dataset_title": "Dataset with a multiplexed Library",
+        "description": "Used to test tools with pooling and demultiplexing",
+        "accession": "LATDS888DMX",
+        "uuid": "c534f486-a442-4ee2-a41e-8ffe007eb6ee",
+        "award": "CZI039LAT",
+        "funding_organizations": [
+            "Chan Zuckerberg Institute"
+        ]
+    },
+    {
+        "aliases": [
             "anna-greka:large_test_dataset"
         ],
         "dataset_title": "The best dataset around",

--- a/src/encoded/tests/data/inserts/library.json
+++ b/src/encoded/tests/data/inserts/library.json
@@ -1,5 +1,19 @@
 [
     {
+        "uuid": "0b5af766-56af-47e3-9e28-e016ddd63bc9",
+        "dataset": "lattice:multiplexed_dataset",
+        "protocol": "10x-3'-v3",
+        "lab": "j-michael-cherry",
+        "derived_from": [
+            "anna-greka:sc_citeseq_suspension_donorA",
+            "anna-greka:sc_citeseq_suspension_donorB",
+            "anindita-basu:suspension_A"
+        ],
+        "aliases": [
+            "lattice:pooled_lib"
+        ]
+    },
+    {
         "status": "released",
         "uuid": "156d9247-f386-4657-b234-a756584bc20f",
         "dataset": "anna-greka:large_test_dataset",

--- a/src/encoded/tests/data/inserts/raw_sequence_file.json
+++ b/src/encoded/tests/data/inserts/raw_sequence_file.json
@@ -1,5 +1,107 @@
 [
     {
+        "accession": "LATDF302DMX",
+        "uuid": "009ba2f6-9bdd-4aca-9731-83c8b28ea0bf",
+        "dataset": "lattice:multiplexed_dataset",
+        "read_type": "Read 2",
+        "file_format": "fastq",
+        "lab": "j-michael-cherry",
+        "output_types": [
+            "assigned reads"
+        ],
+        "derived_from": [
+            "lattice:demux_run_3"
+        ],
+        "derivation_process": [
+            "demultiplexing"
+        ]
+    },
+    {
+        "accession": "LATDF301DMX",
+        "uuid": "8d08ba5a-b6d5-4fa0-923d-b8dd4d455d47",
+        "dataset": "lattice:multiplexed_dataset",
+        "read_type": "Read 1",
+        "file_format": "fastq",
+        "lab": "j-michael-cherry",
+        "output_types": [
+            "assigned reads"
+        ],
+        "derived_from": [
+            "lattice:demux_run_3"
+        ],
+        "derivation_process": [
+            "demultiplexing"
+        ]
+    },
+    {
+        "accession": "LATDF202DMX",
+        "uuid": "0b522079-5a5c-4c8b-ba9b-a4db5f25a2f7",
+        "dataset": "lattice:multiplexed_dataset",
+        "read_type": "Read 2",
+        "file_format": "fastq",
+        "lab": "j-michael-cherry",
+        "output_types": [
+            "assigned reads"
+        ],
+        "derived_from": [
+            "lattice:demux_run_2"
+        ],
+        "derivation_process": [
+            "demultiplexing"
+        ]
+    },
+    {
+        "accession": "LATDF201DMX",
+        "uuid": "9998c791-666f-4336-af55-6b79ccb7d5a1",
+        "dataset": "lattice:multiplexed_dataset",
+        "read_type": "Read 1",
+        "file_format": "fastq",
+        "lab": "j-michael-cherry",
+        "output_types": [
+            "assigned reads"
+        ],
+        "derived_from": [
+            "lattice:demux_run_2"
+        ],
+        "derivation_process": [
+            "demultiplexing"
+        ]
+    },
+    {
+        "accession": "LATDF102DMX",
+        "uuid": "81867b7d-8298-491b-ae76-40fd896fd565",
+        "dataset": "lattice:multiplexed_dataset",
+        "read_type": "Read 2",
+        "file_format": "fastq",
+        "lab": "j-michael-cherry",
+        "output_types": [
+            "assigned reads"
+        ],
+        "derived_from": [
+            "lattice:demux_run_1"
+        ],
+        "derivation_process": [
+            "demultiplexing"
+        ]
+    },
+    {
+        "accession": "LATDF101DMX",
+        "uuid": "8ba834fa-f23e-47aa-8771-76d14774fe95",
+        "dataset": "lattice:multiplexed_dataset",
+        "read_type": "Read 1",
+        "file_format": "fastq",
+        "lab": "j-michael-cherry",
+        "output_types": [
+            "assigned reads"
+        ],
+        "derived_from": [
+            "lattice:demux_run_1"
+        ],
+        "derivation_process": [
+            "demultiplexing"
+        ]
+    },
+    {
         "aliases": [
             "anna-greka:citeseq_donorA1_S1_L001_I1_001.fastq"
         ],

--- a/src/encoded/tests/data/inserts/sequencing_run.json
+++ b/src/encoded/tests/data/inserts/sequencing_run.json
@@ -1,6 +1,30 @@
 [
     {
         "aliases": [
+            "lattice:demux_run_3"
+        ],
+        "derived_from": ["lattice:pooled_lib"],
+        "uuid": "93bfa031-44a2-47ce-bbf0-f5b912ff41ea",
+        "demultiplexed_link": "anindita-basu:suspension_A"
+    },
+    {
+        "aliases": [
+            "lattice:demux_run_2"
+        ],
+        "derived_from": ["lattice:pooled_lib"],
+        "uuid": "71beedec-18ef-449a-bb5c-15f34d7ad5cd",
+        "demultiplexed_link": "anna-greka:sc_citeseq_suspension_donorB"
+    },
+    {
+        "aliases": [
+            "lattice:demux_run_1"
+        ],
+        "derived_from": ["lattice:pooled_lib"],
+        "uuid": "457805b8-7000-4e77-acfb-66f0da50ed92",
+        "demultiplexed_link": "anna-greka:sc_citeseq_suspension_donorA"
+    },
+    {
+        "aliases": [
             "anna-greka:citeseq_run_donorA1"
         ],
 		"status": "released",


### PR DESCRIPTION
Added SequencingRun demultiplexed_link to connect a sequence data back to pre-pooled samples, in the cases where samples were pooled and data were subsequently unpooled/demultiplexed