### PR TITLE
LAT-168 aliases on Donor page

### DIFF
--- a/src/encoded/static/components/dataset.js
+++ b/src/encoded/static/components/dataset.js
@@ -580,13 +580,6 @@ const DatasetComponent = ({ context, auditIndicators, auditDetail }, reactContex
                                 </div>
                             : null}
 
-                            {context.date_released ?
-                                <div data-test="date-released">
-                                    <dt>Date released</dt>
-                                    <dd>{dayjs(context.date_released).format('MMMM D, YYYY')}</dd>
-                                </div>
-                            : null}
-
                             {context.submitter_comment ?
                                 <div data-test="submittercomment">
                                     <dt>Submitter comment</dt>

--- a/src/encoded/static/components/donor.js
+++ b/src/encoded/static/components/donor.js
@@ -40,13 +40,6 @@ const Donor = (props) => {
                             <dd>{biosample ? <a href={context['@id']}>{context.accession}</a> : context.accession}</dd>
                         </div>
 
-                        {context.aliases > 0 ?
-                            <div data-test="aliases">
-                                <dt>Aliases</dt>
-                                <dd>{context.aliases.join(', ')}</dd>
-                            </div>
-                        : null}
-
                         {context.organism.scientific_name ?
                             <div data-test="species">
                                 <dt>Species</dt>
@@ -100,6 +93,13 @@ const Donor = (props) => {
                             <div data-test="references">
                                 <dt>References</dt>
                                 <dd>{references}</dd>
+                            </div>
+                        : null}
+
+                        {context.aliases ?
+                            <div data-test="aliases">
+                                <dt>Aliases</dt>
+                                <dd>{context.aliases.join(', ')}</dd>
                             </div>
                         : null}
 


### PR DESCRIPTION
Fixed a bug so aliases will display on Donor pages
Removed date released from Dataset pages