### PR TITLE
LAT-161 audits midmay

### DIFF
--- a/src/encoded/audit/analysis_file.py
+++ b/src/encoded/audit/analysis_file.py
@@ -21,11 +21,11 @@ def audit_read_count_compare(value, system):
     if value.get('quality_metrics'):
         input_reads = {}
         for df in value.get('derived_from'):
-            if df['@type'][0] not in ['RawSequenceFile']:
+            if df['@type'][0] != 'RawSequenceFile' or df.get('validated') != True:
                 return
-            if df.get('read_count'):
+            seqrun = df['derived_from'][0]['uuid']
+            if seqrun not in input_reads.keys():
                 seqrun_reads = df.get('read_count')
-                seqrun = df['derived_from'][0]['uuid']
                 input_reads[seqrun] = seqrun_reads
         in_reads = 0
         for v in input_reads.values():

--- a/src/encoded/audit/analysis_file.py
+++ b/src/encoded/audit/analysis_file.py
@@ -15,10 +15,13 @@ def audit_read_count_compare(value, system):
     We check fastq metadata against the expected values based on the
     library protocol used to generate the sequence data.
     '''
+    if value['status'] in ['deleted']:
+        return
+
     if value.get('quality_metrics'):
         input_reads = {}
         for df in value.get('derived_from'):
-            if df['@type'][0] not in ['RawSequenceFile','ReferenceFile']:
+            if df['@type'][0] not in ['RawSequenceFile']:
                 return
             if df.get('read_count'):
                 seqrun_reads = df.get('read_count')
@@ -47,6 +50,9 @@ def audit_validated(value, system):
     We check fastq metadata against the expected values based on the
     library protocol used to generate the sequence data.
     '''
+    if value['status'] in ['deleted']:
+        return
+
     if value.get('no_file_available') != True:
         if value.get('s3_uri') or value.get('external_uri'):
             if value.get('validated') != True and value.get('file_format') in ['hdf5']:
@@ -70,8 +76,9 @@ def audit_file_ref_info(value, system):
     A file's reference metadata should match the reference
     metadata of any file it was derived from
     '''
-    if 'derived_from' not in value and 'AnalysisFile' not in value.get('@type'):
+    if value['status'] in ['deleted']:
         return
+
     for f in value['derived_from']:
         for ref_prop in ['assembly', 'genome_annotation']:
             if f.get(ref_prop) and value.get(ref_prop) and \
@@ -96,7 +103,7 @@ def audit_analysis_library_types(value, system):
     if it is from an RNA-seq library.
     We expect CITE-seq libraries to be paired with RNA-seq libraries.
     '''
-    if 'AnalysisFile' not in value.get('@type'):
+    if value['status'] in ['deleted']:
         return
 
     lib_types = set()

--- a/src/encoded/audit/dataset.py
+++ b/src/encoded/audit/dataset.py
@@ -9,6 +9,9 @@ from .formatter import (
 
 
 def audit_contributor_email(value, system):
+    if value['status'] in ['deleted']:
+        return
+
     need_email = []
     if 'corresponding_contributors' in value:
         for user in value['corresponding_contributors']:
@@ -25,6 +28,9 @@ def audit_contributor_email(value, system):
 
 
 def audit_contributor_lists(value, system):
+    if value['status'] in ['deleted']:
+        return
+
     duplicates = []
     if 'contributors' in value and 'corresponding_contributors' in value:
         for user in value['corresponding_contributors']:
@@ -41,8 +47,9 @@ def audit_contributor_lists(value, system):
 
 
 def audit_dataset_no_raw_files(value, system):
-    if value['status'] not in ['released','in progress']:
+    if value['status'] in ['deleted']:
         return
+
     raw_data = False
     if 'original_files' in value:
         for f in value['original_files']:
@@ -58,8 +65,9 @@ def audit_dataset_no_raw_files(value, system):
 
 
 def audit_dataset_dcp_required_properties(value, system):
-    if value['status'] not in ['released','in progress']:
+    if value['status'] in ['deleted']:
         return
+
     dcp_reqs = ['dataset_title', 'description', 'funding_organizations']
     for req in dcp_reqs:
         if req not in value:

--- a/src/encoded/audit/raw_sequence_file.py
+++ b/src/encoded/audit/raw_sequence_file.py
@@ -11,6 +11,9 @@ from .item import STATUS_LEVEL
 
 
 def no_read_type(value, system):
+    if value['status'] in ['deleted']:
+        return
+
     if value.get('no_file_available') != True:
         if not value.get('read_type'):
             detail = ('File {} does not have a read_type.'.format(
@@ -22,6 +25,9 @@ def no_read_type(value, system):
 
 
 def no_file_name(value, system):
+    if value['status'] in ['deleted']:
+        return
+
     if value.get('no_file_available') != True:
         if not value.get('submitted_file_name'):
             detail = ('File {} does not have a submitted_file_name.'.format(
@@ -41,6 +47,9 @@ def no_file_name(value, system):
 
 
 def no_file_stats(value, system):
+    if value['status'] in ['deleted']:
+        return
+
     if value.get('no_file_available') != True and value.get('validated') == True:
         missing = []
         for stat in ['file_size','sha256','crc32c']:
@@ -57,6 +66,9 @@ def no_file_stats(value, system):
 
 
 def not_validated(value, system):
+    if value['status'] in ['deleted']:
+        return
+
     if value.get('no_file_available') != True:
         if value.get('validated') != True:
             detail = ('File {} has not been validated.'.format(
@@ -68,6 +80,9 @@ def not_validated(value, system):
 
 
 def no_uri(value, system):
+    if value['status'] in ['deleted']:
+        return
+
     if value.get('no_file_available') != True:
         if not (value.get('s3_uri') or value.get('external_uri')):
             detail = ('File {} has no s3_uri, external_uri, and is not marked as no_file_available.'.format(
@@ -83,6 +98,9 @@ def audit_library_protocol_standards(value, system):
     We check fastq metadata against the expected values based on the
     library protocol used to generate the sequence data.
     '''
+    if value['status'] in ['deleted']:
+        return
+
     if value.get('no_file_available') != True and value.get('validated') == True:
         lib_prots = set()
         for l in value.get('libraries'):


### PR DESCRIPTION
fixed a bug for the required_files audit when a libraryprotocol has no required files
added a bail out of the audit for inconsisent read count audits - between matrix & rawsequence + between rawsequence of the same sequencingrun - if any of the rawsequence are not validated
added audit to catch multiple files of a single read_type on a sequencingrun
added a status check & exit if ‘deleted’ for analysis_file, dataset (switched some that were acting on in progress/released), raw_sequence_file