### PR TITLE
LAT-196 schema updates end july2021

### DIFF
--- a/src/encoded/audit/donor.py
+++ b/src/encoded/audit/donor.py
@@ -41,7 +41,7 @@ def audit_donor_age(value, system):
 
     years = 0
     if value.get('age_units') == 'month':
-        years = range_min/7
+        years = range_min/12
     elif value.get('age_units') == 'year':
         years = range_min
 
@@ -59,11 +59,12 @@ def audit_donor_dev_stage(value, system):
         return
 
     dev = value['development_ontology']['term_name']
-    post_term_end = '-year-old human stage'
-    pre_term_end = ' week post-fertilization human stage'
+    post_term_end_mo = '-month-old human stage'
+    post_term_end_yr = '-year-old human stage'
+    pre_term_end_wk = ' week post-fertilization human stage'
 
     if value['age_display'] == 'unknown' or '-' in value.get('age','') or '-' in value.get('conceptional_age',''):
-        if dev.endswith(post_term_end) or dev.endswith(pre_term_end):
+        if dev.endswith(post_term_end_yr) or dev.endswith(pre_term_end_wk):
             detail = ('Donor {} of age {} not expected age-specific development_ontology ({}).'.format(
                 audit_link(value['accession'], value['@id']),
                 value.get('age_display'),
@@ -72,61 +73,53 @@ def audit_donor_dev_stage(value, system):
             )
             yield AuditFailure('inconsistent age, development', detail, level='ERROR')
             return
-    elif value.get('age_units') == 'year':
-        if value['age'] == '>89':
-            if dev != '80 year-old and over human stage':
-                detail = ('Donor {} of age {} expected "80 year-old and over human stage" development_ontology, not {}.'.format(
+        else:
+            return
+    elif value.get('conceptional_age_units'):
+        if value.get('conceptional_age_units') == 'week' and int(value.get('conceptional_age')) < 9 or \
+            value.get('conceptional_age_units') == 'day' and int(value.get('conceptional_age')) < 57:
+            if 'embryonic human stage' not in value['development_ontology']['development_slims']:
+                detail = ('Donor {} of age 56 days (8 wk) or less should be embryonic, not {}.'.format(
                     audit_link(value['accession'], value['@id']),
-                    value.get('age_display'),
-                    dev
+                    value['development_ontology']['development_slims']
                     )
                 )
                 yield AuditFailure('inconsistent age, development', detail, level='ERROR')
                 return
-        elif dev != value['age'] + post_term_end:
-            detail = ('Donor {} of age {} expected matching age-specific development_ontology, not {}.'.format(
-                audit_link(value['accession'], value['@id']),
-                value.get('age_display'),
-                dev
-                )
-            )
-            yield AuditFailure('inconsistent age, development', detail, level='ERROR')
+            else:
+                return
+        elif value.get('conceptional_age_units') == 'week' and int(value.get('conceptional_age')) > 8:
+            expected = ordinalize(value['conceptional_age']) + pre_term_end_wk
+        elif value.get('conceptional_age_units') == 'day' and int(value.get('conceptional_age')) > 56:
+            days = int(value['conceptional_age'])
+            week = days//7
+            if days%7 != 0:
+                week += 1
+            expected = ordinalize(str(week)) + pre_term_end_wk
+        else:
             return
-    elif value.get('conceptional_age_units') == 'week' and int(value.get('conceptional_age')) > 8:
-        if dev != ordinalize(value['conceptional_age']) + pre_term_end:
-            detail = ('Donor {} of age {} expected matching age-specific development_ontology, not {}.'.format(
-                audit_link(value['accession'], value['@id']),
-                value.get('age_display'),
-                dev
-                )
-            )
-            yield AuditFailure('inconsistent age, development', detail, level='ERROR')
-            return
-    elif value.get('conceptional_age_units') == 'day' and int(value.get('conceptional_age')) > 56:
-        days = int(value['conceptional_age'])
-        week = days//7
-        if days%7 != 0:
-            week += 1
-        if dev != ordinalize(str(week)) + pre_term_end:
-            detail = ('Donor {} of age {} expected matching age-specific development_ontology, not {}.'.format(
-                audit_link(value['accession'], value['@id']),
-                value.get('age_display'),
-                dev
-                )
-            )
-            yield AuditFailure('inconsistent age, development', detail, level='ERROR')
-            return
-    elif value.get('conceptional_age_units') == 'week' and int(value.get('conceptional_age')) < 9 or \
-        value.get('conceptional_age_units') == 'day' and int(value.get('conceptional_age')) < 57:
-        if 'embryonic human stage' not in value['development_ontology']['development_slims']:
-            detail = ('Donor {} of age 56 days (8 wk) or less should be embryonic, not {}.'.format(
-                audit_link(value['accession'], value['@id']),
-                value['development_ontology']['development_slims']
-                )
-            )
-            yield AuditFailure('inconsistent age, development', detail, level='ERROR')
-            return
+    elif value.get('age_units') == 'year':
+        if value['age'] == '>89':
+            expected = '80 year-old and over human stage'
+        else:
+            expected = value['age'] + post_term_end_yr
+    elif value.get('age_units') == 'month':
+        if float(value['age']) <= 23:
+            expected = value['age'] + post_term_end_mo
+        else:
+            years = int(value['age'])//12
+            expected = str(years) + post_term_end_yr
 
+    if dev != expected:
+        detail = ('Donor {} of age {} expected development_ontology {}, not {}.'.format(
+            audit_link(value['accession'], value['@id']),
+            value.get('age_display'),
+            expected,
+            dev
+            )
+        )
+        yield AuditFailure('inconsistent age, development', detail, level='ERROR')
+        return
 
 
 function_dispatcher = {
@@ -134,7 +127,7 @@ function_dispatcher = {
     'audit_donor_dev_stage': audit_donor_dev_stage
 }
 
-@audit_checker('Donor',
+@audit_checker('HumanDonor',
                frame=['development_ontology'])
 def audit_donor(value, system):
     for function_name in function_dispatcher.keys():

--- a/src/encoded/schemas/changelogs/processed_matrix_file.md
+++ b/src/encoded/schemas/changelogs/processed_matrix_file.md
@@ -1,0 +1,4 @@
+## Changelog for processed_matrix_file.json
+
+### Schema version 4
+* Removed submitted *assembly* and *genome_annotation* in favor of calculated *assemblies* and *genome_annotations*

--- a/src/encoded/schemas/primary_analysis_file.json
+++ b/src/encoded/schemas/primary_analysis_file.json
@@ -1,8 +1,8 @@
 {
-    "title": "Analysis file",
+    "title": "Primary analysis file",
     "description": "Schema for submitting metadata for a data file that is produced from other data files.",
     "comment": "This object type is abstract. These properties are inherited by other object types",
-    "id": "/profiles/analysis_file.json",
+    "id": "/profiles/primary_analysis_file.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "mixinProperties": [],

--- a/src/encoded/schemas/processed_matrix_file.json
+++ b/src/encoded/schemas/processed_matrix_file.json
@@ -22,8 +22,7 @@
         {"$ref": "mixins.json#/uuid"},
         {"$ref": "mixins.json#/accessioned_status"},
         {"$ref": "file.json#/properties"},
-        {"$ref": "data_file.json#/properties"},
-        {"$ref": "analysis_file.json#/properties"}
+        {"$ref": "data_file.json#/properties"}
     ],
     "dependencies": {
         "external_accession": {
@@ -81,7 +80,7 @@
     },
     "properties": {
         "schema_version": {
-            "default": "3"
+            "default": "4"
         }, 
         "description": {
             "description": "The text describing the matrix, will be displayed as the title at cellxgene."
@@ -139,6 +138,13 @@
                     "transcription factor quantifications",
                     "antibody capture quantifications"
                 ]
+            }
+        },
+        "dbxrefs": {
+            "items": {
+                "title": "External identifier",
+                "description": "Identifier from an external resource that may have 1-to-1 or 1-to-many relationships with Lattice objects.",
+                "type":  "string"
             }
         },
         "intronic_reads_counted": {
@@ -447,11 +453,11 @@
         "assays": {
             "title": "Assays"
         },
-        "assembly": {
-            "title": "Genome assembly"
+        "assemblies": {
+            "title": "Genome assemblies"
         },
-        "genome_annotation": {
-            "title": "Genome annotation"
+        "genome_annotations": {
+            "title": "Genome annotations"
         },
         "output_types": {
             "title": "Output type"
@@ -489,8 +495,11 @@
         "dataset": {
             "title": "Dataset"
         },
-        "assembly": {
-            "title": "Genome assembly"
+        "assemblies": {
+            "title": "Genome assemblies"
+        },
+        "genome_annotations": {
+            "title": "Genome annotations"
         },
         "file_format": {
             "title": "File Format"
@@ -503,9 +512,6 @@
         },
         "derived_from": {
             "title": "Derived from"
-        },
-        "genome_annotation": {
-            "title": "Genome annotation"
         },
         "output_types": {
             "title": "Output types"

--- a/src/encoded/schemas/raw_matrix_file.json
+++ b/src/encoded/schemas/raw_matrix_file.json
@@ -23,7 +23,7 @@
         {"$ref": "mixins.json#/accessioned_status"},
         {"$ref": "file.json#/properties"},
         {"$ref": "data_file.json#/properties"},
-        {"$ref": "analysis_file.json#/properties"}
+        {"$ref": "primary_analysis_file.json#/properties"}
     ],
     "dependencies": {
         "external_accession": {

--- a/src/encoded/schemas/sequence_alignment_file.json
+++ b/src/encoded/schemas/sequence_alignment_file.json
@@ -22,7 +22,7 @@
         {"$ref": "mixins.json#/accessioned_status"},
         {"$ref": "file.json#/properties"},
         {"$ref": "data_file.json#/properties"},
-        {"$ref": "analysis_file.json#/properties"}
+        {"$ref": "primary_analysis_file.json#/properties"}
     ],
     "dependencies": {
         "external_accession": {

--- a/src/encoded/schemas/sequencing_run.json
+++ b/src/encoded/schemas/sequencing_run.json
@@ -54,6 +54,7 @@
             "type": "string",
             "enum": [
                 "Illumina NextSeq 500",
+                "Illumina NextSeq 550",
                 "Illumina NovaSeq 6000",
                 "Illumina HiSeq 4000",
                 "Illumina HiSeq 2500",

--- a/src/encoded/tests/data/inserts/processed_matrix_file.json
+++ b/src/encoded/tests/data/inserts/processed_matrix_file.json
@@ -57,8 +57,6 @@
             "peter-sims:postnatal_1b_filtered_matrix",
             "peter-sims:postnatal_1c_filtered_matrix"
         ],
-        "assembly": "GRCh38",
-        "genome_annotation": "GENCODE 32",
         "derivation_process": [
             "merging"
         ],
@@ -136,8 +134,6 @@
             "peter-sims:prenatal_3a_filtered_matrix",
             "peter-sims:prenatal_3b_filtered_matrix"
         ],
-        "assembly": "GRCh38",
-        "genome_annotation": "GENCODE 32",
         "derivation_process": [
             "merging",
             "ambient RNA correction"
@@ -246,8 +242,6 @@
             "anna-greka:donorB1_filtered_feature_bc_matrix",
             "anna-greka:donorB2_filtered_feature_bc_matrix"
         ],
-        "assembly": "GRCh38",
-        "genome_annotation": "GENCODE 32",
         "md5sum": "48912b433c9105e6b4f32c79f6b09f6b",
         "layers": [
             {
@@ -328,8 +322,6 @@
             "anna-greka:donorD2a_filtered_feature_bc_matrix",
             "anna-greka:donorD2b_filtered_feature_bc_matrix"
         ],
-        "assembly": "GRCh38",
-        "genome_annotation": "GENCODE 32",
         "md5sum": "2dd4370d08bdf8666b859c888b1f7006",
         "layers": [
             {
@@ -400,8 +392,6 @@
             "anna-greka:donorCD2_filtered_feature_bc_matrix"
         ],
         "s3_uri": "s3://submissions-czi012eye/chen_2020/19D015_macular_outs/filtered_feature_bc_matrix.h5",
-        "assembly": "GRCh38",
-        "genome_annotation": "GENCODE 32",
         "md5sum": "98b5746b0f69e8be8c888e3c1d74b150",
         "layers": [
             {
@@ -472,8 +462,6 @@
             "anna-greka:donorE_filtered_feature_bc_matrix",
             "anna-greka:donorF_filtered_feature_bc_matrix"
         ],
-        "assembly": "GRCh38",
-        "genome_annotation": "GENCODE 32",
         "md5sum": "ee656a7331492beca246fcb1b503fd33",
         "layers": [
             {
@@ -548,8 +536,6 @@
             "anna-greka:donorG_filtered_feature_bc_matrix",
             "anna-greka:donorH_filtered_feature_bc_matrix"
         ],
-        "assembly": "GRCh38",
-        "genome_annotation": "GENCODE 32",
         "md5sum": "24aaa927d40e8680ea107684c39fb442",
         "layers": [
             {

--- a/src/encoded/tests/data/inserts/sequencing_run.json
+++ b/src/encoded/tests/data/inserts/sequencing_run.json
@@ -8,7 +8,7 @@
         ],
         "uuid": "93bfa031-44a2-47ce-bbf0-f5b912ff41ea",
         "demultiplexed_link": "anindita-basu:suspension_A",
-        "platform": "Illumina NovaSeq 6000"
+        "platform": "Illumina NextSeq 550"
     },
     {
         "aliases": [

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -208,7 +208,6 @@ class AnalysisFile(DataFile):
     item_type = 'analysis_file'
     base_types = ['AnalysisFile'] + DataFile.base_types
     rev = {}
-    schema = load_schema('encoded:schemas/analysis_file.json')
     embedded = DataFile.embedded + []
 
 
@@ -466,3 +465,45 @@ class ProcessedMatrixFile(AnalysisFile):
     def cell_annotations(self, request, cell_annotations=None):
         if cell_annotations:
             return paths_filtered_by_status(request, cell_annotations)
+
+
+    @calculated_property(schema={
+        "title": "Genome annotations",
+        "description": "The genome annotations used as references during the generation of the data in this file.",
+        "comment": "Do not submit. This is a calculated property",
+        "type": "array",
+        "items": {
+            "type": 'string'
+        },
+        "notSubmittable": True,
+    })
+    def genome_annotations(self, request, derived_from):
+        refs = set()
+        for f in derived_from:
+            obj = request.embed(f, '@@object')
+            if obj.get('genome_annotation'):
+                refs.add(obj.get('genome_annotation'))
+            elif obj.get('genome_annotations'):
+                refs.update(obj.get('genome_annotations'))
+        return sorted(refs)
+
+
+    @calculated_property(schema={
+        "title": "Assemblies",
+        "description": "The genome assemblies used as references during the generation of the data in this file.",
+        "comment": "Do not submit. This is a calculated property",
+        "type": "array",
+        "items": {
+            "type": 'string'
+        },
+        "notSubmittable": True,
+    })
+    def assemblies(self, request, derived_from):
+        refs = set()
+        for f in derived_from:
+            obj = request.embed(f, '@@object')
+            if obj.get('assembly'):
+                refs.add(obj.get('assembly'))
+            elif obj.get('assemblies'):
+                refs.update(obj.get('assemblies'))
+        return sorted(refs)

--- a/src/encoded/upgrade/file.py
+++ b/src/encoded/upgrade/file.py
@@ -6,3 +6,10 @@ from snovault import upgrade_step
 def analysis_file_1_2(value, system):
 	if 'award' in value:
 		del value['award']
+
+@upgrade_step('processed_matrix_file', '3', '4')
+def processed_matrix_file_3_4(value, system):
+	if 'assembly' in value:
+		del value['assembly']
+	if 'genome_annotation' in value:
+		del value['genome_annotation']


### PR DESCRIPTION
added Illumina NextSeq550 to SequencingRun platform enum

LAT-195 changes
updated the audit to divide months by 12, not 7, to get years (confirmed locally that a donor of 1080 months triggers the audit, but 1079 does not)
added audit if a donor age_units==months. 23 or less should be month-specific dev term, 24 and up should be year-specific

LAT-197 changes
Moved analysis_file schema to primary_analysis_file schema (incl reference fields) and only linked rawmatrixfile & sequencealignmentfile to primary_analysis_file (not processed_matrix_file)
added upgrade to remove assembly and genome_annotation from processed_matrix_file objects
calculated assemblies and genome_annotations in processed_matrix_file based on derived_from