### PR TITLE
LAT-199 fix prenatal donor audit bugs

### DIFF
--- a/src/encoded/audit/donor.py
+++ b/src/encoded/audit/donor.py
@@ -76,8 +76,8 @@ def audit_donor_dev_stage(value, system):
         else:
             return
     elif value.get('conceptional_age_units'):
-        if value.get('conceptional_age_units') == 'week' and int(value.get('conceptional_age')) < 9 or \
-            value.get('conceptional_age_units') == 'day' and int(value.get('conceptional_age')) < 57:
+        if value.get('conceptional_age_units') == 'week' and float(value.get('conceptional_age')) <= 8 or \
+            value.get('conceptional_age_units') == 'day' and float(value.get('conceptional_age')) <= 56:
             if 'embryonic human stage' not in value['development_ontology']['development_slims']:
                 detail = ('Donor {} of age 56 days (8 wk) or less should be embryonic, not {}.'.format(
                     audit_link(value['accession'], value['@id']),
@@ -88,9 +88,13 @@ def audit_donor_dev_stage(value, system):
                 return
             else:
                 return
-        elif value.get('conceptional_age_units') == 'week' and int(value.get('conceptional_age')) > 8:
-            expected = ordinalize(value['conceptional_age']) + pre_term_end_wk
-        elif value.get('conceptional_age_units') == 'day' and int(value.get('conceptional_age')) > 56:
+        elif value.get('conceptional_age_units') == 'week' and float(value.get('conceptional_age')) > 8:
+            week = float(value['conceptional_age'])
+            if week %1 != 0:
+                week += 1
+            week = int(week//1)
+            expected = ordinalize(str(week)) + pre_term_end_wk
+        elif value.get('conceptional_age_units') == 'day' and float(value.get('conceptional_age')) > 56:
             days = int(value['conceptional_age'])
             week = days//7
             if days%7 != 0:


### PR DESCRIPTION
updated audit from <9 weeks to <=8 weeks should be embryonic (changed from <57 days to <=56 days for consistency)
updated the weeks audit to handle integers